### PR TITLE
Build with go-1.11 and miscellaneous fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-  - 1.7
+  - 1.9
   - tip

--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -157,6 +157,9 @@ func (cc *ClientConductor) Init(driverProxy *driver.Proxy, bcast *broadcast.Copy
 	cc.pendingCloses = make(map[int64]chan bool)
 	cc.lingeringResources = make(chan lingerResourse, 1024)
 
+	cc.pubs = make([]*publicationStateDefn, 0)
+	cc.subs = make([]*subscriptionStateDefn, 0)
+
 	return cc
 }
 

--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -438,24 +438,22 @@ func (cc *ClientConductor) OnNewExclusivePublication(streamID int32, sessionID i
 	cc.adminLock.Lock()
 	defer cc.adminLock.Unlock()
 
-	log.Panic("OnNewExclusivePublication: Not supported yet")
+	for _, pubDef := range cc.pubs {
+		if pubDef.regID == regID {
+			pubDef.status = RegistrationStatus.RegisteredMediaDriver
+			pubDef.sessionID = sessionID
+			pubDef.posLimitCounterID = posLimitCounterID
+			pubDef.channelStatusIndicatorID = channelStatusIndicatorID
+			pubDef.buffers = logbuffer.Wrap(logFileName)
+			pubDef.origRegID = origRegID
 
-	//for _, pubDef := range cc.pubs {
-	//	if pubDef.regID == regID {
-	//		pubDef.status = RegistrationStatus.RegisteredMediaDriver
-	//		pubDef.sessionID = sessionID
-	//		pubDef.posLimitCounterID = posLimitCounterID
-	//		pubDef.channelStatusIndicatorID = channelStatusIndicatorID
-	//		pubDef.buffers = logbuffer.Wrap(logFileName)
-	//		pubDef.origRegID = origRegID
-	//
-	//		logger.Debugf("Updated publication: %v", pubDef)
-	//
-	//		if cc.onNewPublicationHandler != nil {
-	//			cc.onNewPublicationHandler(pubDef.channel, streamID, sessionID, regID)
-	//		}
-	//	}
-	//}
+			logger.Debugf("Updated publication: %v", pubDef)
+
+			if cc.onNewPublicationHandler != nil {
+				cc.onNewPublicationHandler(pubDef.channel, streamID, sessionID, regID)
+			}
+		}
+	}
 }
 
 func (cc *ClientConductor) OnAvailableCounter(correlationID int64, counterID int32) {
@@ -465,7 +463,7 @@ func (cc *ClientConductor) OnAvailableCounter(correlationID int64, counterID int
 	cc.adminLock.Lock()
 	defer cc.adminLock.Unlock()
 
-	log.Panic("OnAvailableCounter: Not supported yet")
+	logger.Warning("OnAvailableCounter: Not supported yet")
 }
 
 func (cc *ClientConductor) OnUnavailableCounter(correlationID int64, counterID int32) {
@@ -475,7 +473,7 @@ func (cc *ClientConductor) OnUnavailableCounter(correlationID int64, counterID i
 	cc.adminLock.Lock()
 	defer cc.adminLock.Unlock()
 
-	log.Panic("OnUnavailableCounter: Not supported yet")
+	logger.Warning("OnUnavailableCounter: Not supported yet")
 }
 
 func (cc *ClientConductor) OnSubscriptionReady(correlationID int64, channelStatusIndicatorID int32) {

--- a/aeron/logbuffer/FrameDescriptor.go
+++ b/aeron/logbuffer/FrameDescriptor.go
@@ -33,12 +33,44 @@ func lengthOffset(frameOffset int32) int32 {
 	return frameOffset + DataFrameHeader.FrameLengthFieldOffset
 }
 
+func termIdOffset(frameOffset int32) int32 {
+	return frameOffset + DataFrameHeader.TermIDFieldOffset
+}
+
+func sessionIdOffset(frameOffset int32) int32 {
+	return frameOffset + DataFrameHeader.SessionIDFieldOffset
+}
+
+func streamIdOffset(frameOffset int32) int32 {
+	return frameOffset + DataFrameHeader.StreamIDFieldOffset
+}
+
 func ComputeMaxMessageLength(capacity int32) int32 {
 	return capacity / 8
 }
 
 func typeOffset(frameOffset int32) int32 {
 	return frameOffset + DataFrameHeader.TypeFieldOffset
+}
+
+func GetFlags(logBuffer *atomic.Buffer, frameOffset int32) uint8 {
+	offset := flagsOffset(frameOffset)
+	return logBuffer.GetUInt8(offset)
+}
+
+func GetTermId(logBuffer *atomic.Buffer, frameOffset int32) int32 {
+	offset := termIdOffset(frameOffset)
+	return logBuffer.GetInt32Volatile(offset)
+}
+
+func GetSessionId(logBuffer *atomic.Buffer, frameOffset int32) int32 {
+	offset := sessionIdOffset(frameOffset)
+	return logBuffer.GetInt32Volatile(offset)
+}
+
+func GetStreamId(logBuffer *atomic.Buffer, frameOffset int32) int32 {
+	offset := streamIdOffset(frameOffset)
+	return logBuffer.GetInt32Volatile(offset)
 }
 
 func GetFrameLength(logBuffer *atomic.Buffer, frameOffset int32) int32 {

--- a/aeron/stat/aeron_stat.go
+++ b/aeron/stat/aeron_stat.go
@@ -28,7 +28,7 @@ var ansiHome = "\u001b[H"
 
 func main() {
 	ctx := aeron.NewContext()
-	counterFile, _ := counters.MapFile(ctx.CncFileName())
+	counterFile, _, _ := counters.MapFile(ctx.CncFileName())
 
 	reader := counters.NewReader(counterFile.ValuesBuf.Get(), counterFile.MetaDataBuf.Get())
 

--- a/systests/systest.go
+++ b/systests/systest.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
 	"github.com/lirm/aeron-go/aeron/logbuffer"
 	"github.com/op/go-logging"
@@ -38,7 +39,7 @@ var ExamplesConfig = struct {
 
 var logger = logging.MustGetLogger("systests")
 
-func send(n int, pub *Publication) {
+func send(n int, pub *aeron.Publication) {
 	message := "this is a message"
 	srcBuffer := atomic.MakeBuffer(([]byte)(message))
 
@@ -55,7 +56,7 @@ func send(n int, pub *Publication) {
 	}
 }
 
-func receive(n int, sub *Subscription) {
+func receive(n int, sub *aeron.Subscription) {
 	counter := 0
 	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
 		logger.Debugf("    message: %s", string(buffer.GetBytesArray(offset, length)))
@@ -86,12 +87,12 @@ func receive(n int, sub *Subscription) {
 	}
 }
 
-func subAndSend(n int, a *Aeron, pub *Publication) {
+func subAndSend(n int, a *aeron.Aeron, pub *aeron.Publication) {
 	sub := <-a.AddSubscription(*ExamplesConfig.TestChannel, int32(*ExamplesConfig.TestStreamID))
 	defer sub.Close()
 
 	// This is basically a requirement since we need to wait
-	for !IsConnectedTo(sub, pub) {
+	for !aeron.IsConnectedTo(sub, pub) {
 		time.Sleep(time.Millisecond)
 	}
 
@@ -124,7 +125,7 @@ func logtest(flag bool) {
 func testAeronBasics() {
 	logger.Debug("Started TestAeronBasics")
 
-	a, err := Connect(NewContext())
+	a, err := aeron.Connect(aeron.NewContext())
 	if err != nil {
 		logger.Fatalf("Failed to connect to driver: %s\n", err.Error())
 	}
@@ -142,7 +143,7 @@ func testAeronBasics() {
 func testAeronSendMultipleMessages() {
 	logger.Debug("Started TestAeronSendMultipleMessages")
 
-	a, err := Connect(NewContext())
+	a, err := aeron.Connect(aeron.NewContext())
 	if err != nil {
 		logger.Fatalf("Failed to connect to driver: %s\n", err.Error())
 	}
@@ -155,7 +156,7 @@ func testAeronSendMultipleMessages() {
 	defer sub.Close()
 
 	// This is basically a requirement since we need to wait
-	for !IsConnectedTo(sub, pub) {
+	for !aeron.IsConnectedTo(sub, pub) {
 		time.Sleep(time.Millisecond)
 	}
 
@@ -181,7 +182,7 @@ func testAeronSendMultiplePublications() {
 	//	}
 	//}()
 
-	a, err := Connect(NewContext())
+	a, err := aeron.Connect(aeron.NewContext())
 	if err != nil {
 		logger.Fatalf("Failed to connect to driver: %s\n", err.Error())
 	}
@@ -193,7 +194,7 @@ func testAeronSendMultiplePublications() {
 	sub := <-a.AddSubscription(*ExamplesConfig.TestChannel, int32(*ExamplesConfig.TestStreamID))
 	defer sub.Close()
 
-	pubs := make([]*Publication, pubCount)
+	pubs := make([]*aeron.Publication, pubCount)
 
 	for i := 0; i < pubCount; i++ {
 		pub := <-a.AddPublication(*ExamplesConfig.TestChannel, int32(*ExamplesConfig.TestStreamID))
@@ -202,7 +203,7 @@ func testAeronSendMultiplePublications() {
 		pubs[i] = pub
 
 		// This is basically a requirement since we need to wait
-		for !IsConnectedTo(sub, pub) {
+		for !aeron.IsConnectedTo(sub, pub) {
 			time.Sleep(time.Millisecond)
 		}
 	}
@@ -228,7 +229,7 @@ func testAeronSendMultiplePublications() {
 func testAeronResubscribe() {
 	logger.Debug("Started TestAeronResubscribe")
 
-	a, err := Connect(NewContext())
+	a, err := aeron.Connect(aeron.NewContext())
 	if err != nil {
 		logger.Fatal("Failed to connect to driver")
 	}
@@ -244,7 +245,7 @@ func testAeronResubscribe() {
 func testResubStress() {
 	logger.Debug("Started TestAeronResubscribe")
 
-	a, err := Connect(NewContext())
+	a, err := aeron.Connect(aeron.NewContext())
 	if err != nil {
 		logger.Fatalf("Failed to connect to driver: %s\n", err.Error())
 	}
@@ -261,8 +262,8 @@ func testResubStress() {
 func testAeronClose() {
 	logger.Debug("Started TestAeronClose")
 
-	ctx := NewContext().MediaDriverTimeout(time.Second * 5)
-	a, err := Connect(ctx)
+	ctx := aeron.NewContext().MediaDriverTimeout(time.Second * 5)
+	a, err := aeron.Connect(ctx)
 	if err != nil {
 		logger.Fatalf("Failed to connect to driver: %s\n", err.Error())
 	}

--- a/systests/systest.go
+++ b/systests/systest.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
 	"github.com/lirm/aeron-go/aeron/logbuffer"
 	"github.com/op/go-logging"
@@ -101,7 +100,7 @@ func subAndSend(n int, a *Aeron, pub *Publication) {
 }
 
 func logtest(flag bool) {
-	fmt.Printf("Logging: %@\n", flag)
+	fmt.Printf("Logging: %t\n", flag)
 	if flag {
 		logging.SetLevel(logging.DEBUG, "aeron")
 		logging.SetLevel(logging.DEBUG, "memmap")


### PR DESCRIPTION
There were a few small build breaks for go-1.11. I added a few missing Header accessors that I needed. The last commit changes the library to warn when it detects unsupported features being used instead of panicing. I found that consuming exclusive publications work OK for my use case using the regular publication code.