### PR TITLE
Fix reservedValueSupplier nil bug

### DIFF
--- a/aeron/publication.go
+++ b/aeron/publication.go
@@ -111,6 +111,10 @@ func (pub *Publication) Close() error {
 func (pub *Publication) Offer(buffer *atomic.Buffer, offset int32, length int32, reservedValueSupplier term.ReservedValueSupplier) int64 {
 
 	newPosition := PublicationClosed
+	
+	if reservedValueSupplier == nil {
+		reservedValueSupplier = term.DefaultReservedValueSupplier
+	}
 
 	if !pub.IsClosed() {
 


### PR DESCRIPTION
Fixes bug in `Offer()` whereby calling the procedure with a nil value for `reservedValueSupplier` and a length exceeding the MTU causes the program to crash.