### PR TITLE
Context.AeronDir now specifies the path to cnc.dat (#36)

### DIFF
--- a/aeron/context.go
+++ b/aeron/context.go
@@ -45,7 +45,7 @@ type Context struct {
 func NewContext() *Context {
 	ctx := new(Context)
 
-	ctx.aeronDir = DefaultAeronDir
+	ctx.aeronDir = DefaultAeronDir + "/aeron-" + UserName
 
 	ctx.errorHandler = func(err error) { logger.Error(err) }
 
@@ -113,5 +113,5 @@ func (ctx *Context) UnavailableImageHandler(handler func(*Image)) *Context {
 
 // CncFileName returns the name of the Counters file
 func (ctx *Context) CncFileName() string {
-	return ctx.aeronDir + "/aeron-" + UserName + "/" + counters.CncFile
+	return ctx.aeronDir + "/" + counters.CncFile
 }


### PR DESCRIPTION
Previously setting Context.AeronDir would change the root path that
then has the username appeneded. This changes it to be set explicitly,
making it consistent with Aeron's C++ and Java clients.

The default Context.AeronDir is unchanged, but this is a breaking
change for those who specific Context.AeronDir.