### PR TITLE
Go 1.12 modules support + fixes + extra functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 go:
   - 1.9
+  - 1.15
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 
 go:
-  - 1.9
   - 1.15
   - tip

--- a/aeron/atomic/buffer.go
+++ b/aeron/atomic/buffer.go
@@ -266,6 +266,16 @@ func (buf *Buffer) GetBytesArray(offset int32, length int32) []byte {
 	return bArr
 }
 
+func (buf *Buffer) GetBytes(offset int32, b []byte) {
+	length := len(b)
+	BoundsCheck(offset, int32(length), buf.length)
+
+	for ix := 0; ix < length; ix++ {
+		uptr := unsafe.Pointer(uintptr(buf.bufferPtr) + uintptr(offset) + uintptr(ix))
+		b[ix] = *(*uint8)(uptr)
+	}
+}
+
 // WriteBytes writes data from offset and length to the given dest buffer. This will
 // grow the buffer as needed.
 func (buf *Buffer) WriteBytes(dest *bytes.Buffer, offset int32, length int32) {

--- a/aeron/channeluri.go
+++ b/aeron/channeluri.go
@@ -1,0 +1,171 @@
+package aeron
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ChannelUri is a parser for Aeron channel URIs. The format is:
+// aeron-uri = "aeron:" media [ "?" param *( "|" param ) ]
+// media     = *( "[^?:]" )
+// param     = key "=" value
+// key       = *( "[^=]" )
+// value     = *( "[^|]" )
+//
+// Multiple params with the same key are allowed, the last value specified takes precedence.
+type ChannelUri struct {
+	prefix string
+	media  string
+	params map[string]string
+}
+
+// AeronScheme is a URI Scheme for Aeron channels and destinations.
+const AeronScheme = "aeron"
+
+// SpyQualifier is a qualifier for spy subscriptions which spy on outgoing network destined traffic efficiently.
+const SpyQualifier = "aeron-spy"
+
+// IpcMedia is the media for IPC.
+const IpcMedia = "ipc"
+
+const spyPrefix = SpyQualifier + ":"
+const aeronPrefix = AeronScheme + ":"
+
+type parseState int8
+
+const (
+	parseStateMedia parseState = iota + 1
+	parseStateParamsKey
+	parseStateParamsValue
+)
+
+// ParseChannelUri parses a string which contains an Aeron URI.
+func ParseChannelUri(uriStr string) (uri ChannelUri, err error) {
+	uri.params = make(map[string]string)
+	if strings.HasPrefix(uriStr, spyPrefix) {
+		uri.prefix = SpyQualifier
+		uriStr = uriStr[len(spyPrefix):]
+	}
+	if !strings.HasPrefix(uriStr, aeronPrefix) {
+		err = fmt.Errorf("aeron URIs must start with 'aeron:', found '%s'", uriStr)
+		return
+	}
+	uriStr = uriStr[len(aeronPrefix):]
+
+	state := parseStateMedia
+	value := ""
+	key := ""
+	for len(uriStr) > 0 {
+		c := uriStr[0]
+		switch state {
+		case parseStateMedia:
+			switch c {
+			case '?':
+				uri.media = value
+				value = ""
+				state = parseStateParamsKey
+			case ':':
+				err = fmt.Errorf("encountered ':' within media definition")
+				return
+			default:
+				value += string(c)
+			}
+		case parseStateParamsKey:
+			if c == '=' {
+				key = value
+				value = ""
+				state = parseStateParamsValue
+			} else {
+				value += string(c)
+			}
+		case parseStateParamsValue:
+			if c == '|' {
+				uri.params[key] = value
+				value = ""
+				state = parseStateParamsKey
+			} else {
+				value += string(c)
+			}
+		default:
+			panic("unexpected state")
+		}
+		uriStr = uriStr[1:]
+	}
+	switch state {
+	case parseStateMedia:
+		uri.media = value
+	case parseStateParamsValue:
+		uri.params[key] = value
+	default:
+		err = fmt.Errorf("no more input found")
+	}
+	return
+}
+
+// Clone returns a deep copy of a ChannelUri.
+func (uri ChannelUri) Clone() (res ChannelUri) {
+	res.prefix = uri.prefix
+	res.media = uri.media
+	res.params = make(map[string]string)
+	for k, v := range uri.params {
+		res.params[k] = v
+	}
+	return
+}
+
+func (uri ChannelUri) Scheme() string {
+	return AeronScheme
+}
+
+func (uri ChannelUri) Prefix() string {
+	return uri.prefix
+}
+
+func (uri ChannelUri) Media() string {
+	return uri.media
+}
+
+func (uri *ChannelUri) SetPrefix(prefix string) {
+	uri.prefix = prefix
+}
+
+func (uri ChannelUri) SetMedia(media string) {
+	uri.media = media
+}
+
+func (uri ChannelUri) Get(key string) string {
+	return uri.params[key]
+}
+
+func (uri ChannelUri) Set(key string, value string) {
+	uri.params[key] = value
+}
+
+func (uri ChannelUri) Remove(key string) {
+	delete(uri.params, key)
+}
+
+func (uri ChannelUri) String() (result string) {
+	if uri.prefix != "" {
+		result += uri.prefix
+		if !strings.HasSuffix(uri.prefix, ":") {
+			result += ":"
+		}
+	}
+	result += aeronPrefix
+	result += uri.media
+	if len(uri.params) > 0 {
+		result += "?"
+		sortedKeys := make([]string, 0, len(uri.params))
+		for k := range uri.params {
+			sortedKeys = append(sortedKeys, k)
+		}
+		sort.Strings(sortedKeys)
+		for _, k := range sortedKeys {
+			result += k + "=" + uri.params[k] + "|"
+		}
+		result = result[:len(result)-1]
+	}
+	return
+}

--- a/aeron/channeluri_test.go
+++ b/aeron/channeluri_test.go
@@ -1,0 +1,95 @@
+package aeron
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChannelUri(t *testing.T) {
+	assert := assert.New(t)
+
+	assertParseWithMedia(assert, "aeron:udp", "udp")
+	assertParseWithMedia(assert, "aeron:ipc", "ipc")
+	assertParseWithMedia(assert, "aeron:", "")
+	assertParseWithMediaAndPrefix(assert, "aeron-spy:aeron:ipc", "aeron-spy", "ipc")
+}
+
+func TestShouldRejectUriWithoutAeronPrefix(t *testing.T) {
+	assert := assert.New(t)
+	assertInvalid(assert, ":udp")
+	assertInvalid(assert, "aeron")
+	assertInvalid(assert, "aron:")
+	assertInvalid(assert, "eeron:")
+}
+
+func TestShouldRejectWithOutOfPlaceColon(t *testing.T) {
+	assert := assert.New(t)
+	assertInvalid(assert, "aeron:udp:")
+}
+
+func TestShouldParseWithMultipleParameters(t *testing.T) {
+	assert := assert.New(t)
+	assertParseWithParams(
+		assert,
+		"aeron:udp?endpoint=224.10.9.8|port=4567|interface=199.168.0.3|ttl=16",
+		"endpoint", "224.10.9.8",
+		"port", "4567",
+		"interface", "199.168.0.3",
+		"ttl", "16")
+}
+
+func TestShouldRoundTripToString(t *testing.T) {
+	assert := assert.New(t)
+
+	assertRoundTrip(assert, "aeron:udp?endpoint=224.10.9.8:777")
+	assertRoundTrip(assert, "aeron-spy:aeron:udp?control=224.10.9.8:777")
+}
+
+func TestCloneShouldRoundTripToString(t *testing.T) {
+	assert := assert.New(t)
+
+	assertCloneRoundTrip(assert, "aeron:udp?endpoint=224.10.9.8:777")
+	assertCloneRoundTrip(assert, "aeron-spy:aeron:udp?control=224.10.9.8:777")
+	assertCloneRoundTrip(assert, "aeron:udp?endpoint=224.10.9.8|interface=199.168.0.3|port=4567|ttl=16")
+}
+
+func assertRoundTrip(assert *assert.Assertions, uriString string) {
+	uri, err := ParseChannelUri(uriString)
+	assert.NoError(err)
+	assert.EqualValues(uriString, uri.String())
+}
+
+func assertCloneRoundTrip(assert *assert.Assertions, uriString string) {
+	uri, err := ParseChannelUri(uriString)
+	assert.NoError(err)
+	assert.EqualValues(uriString, uri.Clone().String())
+}
+
+func assertParseWithParams(assert *assert.Assertions, uriString string, params ...string) {
+	uri, err := ParseChannelUri(uriString)
+	assert.NoError(err)
+	if len(params)%2 != 0 {
+		panic("must be key=value params")
+	}
+	for i := 0; i < len(params); i += 2 {
+		assert.EqualValues(uri.Get(params[i]), params[i+1])
+	}
+}
+
+func assertInvalid(assert *assert.Assertions, uriString string) {
+	_, err := ParseChannelUri(uriString)
+	assert.Error(err)
+}
+
+func assertParseWithMediaAndPrefix(assert *assert.Assertions, uriString string, prefix string, media string) {
+	uri, err := ParseChannelUri(uriString)
+	assert.NoError(err)
+	assert.EqualValues(uri.Scheme(), "aeron")
+	assert.EqualValues(uri.Prefix(), prefix)
+	assert.EqualValues(uri.Media(), media)
+}
+
+func assertParseWithMedia(assert *assert.Assertions, uriString string, media string) {
+	assertParseWithMediaAndPrefix(assert, uriString, "", media)
+}

--- a/aeron/context.go
+++ b/aeron/context.go
@@ -17,9 +17,10 @@ limitations under the License.
 package aeron
 
 import (
+	"time"
+
 	"github.com/lirm/aeron-go/aeron/counters"
 	"github.com/lirm/aeron-go/aeron/idlestrategy"
-	"time"
 )
 
 // Context configuration options are located here https://github.com/real-logic/Aeron/wiki/Configuration-Options#aeron-client-options
@@ -114,4 +115,11 @@ func (ctx *Context) UnavailableImageHandler(handler func(*Image)) *Context {
 // CncFileName returns the name of the Counters file
 func (ctx *Context) CncFileName() string {
 	return ctx.aeronDir + "/" + counters.CncFile
+}
+
+// IdleStrategy provides an IdleStrategy for the thread responsible for communicating
+// with the Aeron Media Driver.
+func (ctx *Context) IdleStrategy(idleStrategy idlestrategy.Idler) *Context {
+	ctx.idleStrategy = idleStrategy
+	return ctx
 }

--- a/aeron/driver/proxy.go
+++ b/aeron/driver/proxy.go
@@ -161,7 +161,8 @@ func (driver *Proxy) AddExclusivePublication(channel string, streamID int32) int
 func (driver *Proxy) RemovePublication(registrationID int64) {
 	correlationID := driver.toDriverCommandBuffer.NextCorrelationID()
 
-	logger.Debugf("driver.RemovePublication: correlationId=%d (pudId=%d)", correlationID, registrationID)
+	logger.Debugf("driver.RemovePublication: clientId=%d correlationId=%d (regId=%d)",
+		driver.clientID, correlationID, registrationID)
 
 	filler := func(buffer *atomic.Buffer, length *int) int32 {
 

--- a/aeron/idlestrategy/backoffidlestrategy.go
+++ b/aeron/idlestrategy/backoffidlestrategy.go
@@ -1,0 +1,109 @@
+package idlestrategy
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// BackoffIdleStrategy is an idling strategy for threads when they have no work to do.
+// Spin for maxSpins, then yield with runtime.Gosched for maxYields,
+// then park with time.Sleep on an exponential backoff to maxParkPeriodNs.
+type BackoffIdleStrategy struct {
+	// configured max spins, yield, and min / max park period
+	maxSpins, maxYields, minParkPeriodNs, maxParkPeriodNs int64
+	// current state
+	state backoffState
+	// current number of spins, yield, and park period.
+	spins, yields, parkPeriodNs int64
+}
+
+// NewBackoffIdleStrategy returns a BackoffIdleStrategy with the given parameters.
+func NewBackoffIdleStrategy(maxSpins, maxYields, minParkPeriodNs, maxParkPeriodNs int64) *BackoffIdleStrategy {
+	return &BackoffIdleStrategy{
+		maxSpins:        maxSpins,
+		maxYields:       maxYields,
+		minParkPeriodNs: minParkPeriodNs,
+		maxParkPeriodNs: maxParkPeriodNs,
+	}
+}
+
+// DefaultMaxSpins is the default number of times the strategy will spin without work before going to next state.
+const DefaultMaxSpins = 10
+
+// DefaultMaxYields is the default number of times the strategy will yield without work before going to next state.
+const DefaultMaxYields = 20
+
+// DefaultMinParkNs is the default interval the strategy will park the thread on entering the park state.
+const DefaultMinParkNs = 1000
+
+// DefaultMaxParkNs is the default interval the strategy will park the thread will expand interval to as a max.
+const DefaultMaxParkNs = int64(1 * time.Millisecond)
+
+// NewDefaultBackoffIdleStrategy returns a BackoffIdleStrategy using DefaultMaxSpins, DefaultMaxYields,
+// DefaultMinParkNs, and DefaultMaxParkNs.
+func NewDefaultBackoffIdleStrategy() *BackoffIdleStrategy {
+	return NewBackoffIdleStrategy(DefaultMaxSpins, DefaultMaxYields, DefaultMinParkNs, DefaultMaxParkNs)
+}
+
+type backoffState int8
+
+const (
+	// Denotes a non-idle state.
+	backoffNotIdle backoffState = iota
+	// Denotes a spinning state.
+	backoffSpinning
+	// Denotes an yielding state.
+	backoffYielding
+	// Denotes a parking state.
+	backoffParking
+)
+
+func (s *BackoffIdleStrategy) Idle(workCount int) {
+	if workCount > 0 {
+		s.reset()
+	} else {
+		s.idle()
+	}
+}
+
+func (s *BackoffIdleStrategy) String() string {
+	return fmt.Sprintf("BackoffIdleStrategy(MaxSpins:%d, MaxYields:%d, MinParkPeriodNs:%d, MaxParkPeriodNs:%d)",
+		s.maxSpins, s.maxYields, s.minParkPeriodNs, s.maxParkPeriodNs)
+}
+
+func (s *BackoffIdleStrategy) reset() {
+	s.spins = 0
+	s.yields = 0
+	s.parkPeriodNs = s.minParkPeriodNs
+	s.state = backoffNotIdle
+}
+
+func (s *BackoffIdleStrategy) idle() {
+	switch s.state {
+	case backoffNotIdle:
+		s.state = backoffSpinning
+		s.spins++
+	case backoffSpinning:
+		// We should call procyield here, see https://golang.org/src/runtime/lock_futex.go
+		s.spins++
+		if s.spins > s.maxSpins {
+			s.state = backoffYielding
+			s.yields = 0
+		}
+	case backoffYielding:
+		s.yields++
+		if s.yields > s.maxYields {
+			s.state = backoffParking
+			s.parkPeriodNs = s.minParkPeriodNs
+		} else {
+			runtime.Gosched()
+		}
+	case backoffParking:
+		time.Sleep(time.Nanosecond * time.Duration(s.parkPeriodNs))
+		s.parkPeriodNs = s.parkPeriodNs << 1
+		if s.parkPeriodNs > s.maxParkPeriodNs {
+			s.parkPeriodNs = s.maxParkPeriodNs
+		}
+	}
+}

--- a/aeron/image.go
+++ b/aeron/image.go
@@ -126,6 +126,11 @@ func (image *Image) Poll(handler term.FragmentHandler, fragmentLimit int) int {
 	return result
 }
 
+// Position returns the position this Image has been consumed to by the subscriber.
+func (image *Image) Position() int64 {
+	return image.subscriberPosition.get()
+}
+
 // Close the image and mappings. The image becomes unusable after closing.
 func (image *Image) Close() error {
 	var err error

--- a/aeron/image.go
+++ b/aeron/image.go
@@ -91,7 +91,7 @@ func NewImage(sessionID int32, correlationID int64, logBuffers *logbuffer.LogBuf
 	}
 	capacity := logBuffers.Buffer(0).Capacity()
 	image.termLengthMask = capacity - 1
-	image.positionBitsToShift = util.NumberOfTrailingZeroes(capacity)
+	image.positionBitsToShift = util.NumberOfTrailingZeroes(uint32(capacity))
 	image.header.SetInitialTermID(logBuffers.Meta().InitTermID.Get())
 	image.header.SetPositionBitsToShift(int32(image.positionBitsToShift))
 	image.isClosed.Set(false)

--- a/aeron/image.go
+++ b/aeron/image.go
@@ -25,10 +25,6 @@ import (
 
 type ControlledPollFragmentHandler func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header)
 
-const (
-	ImageClosed int = -1
-)
-
 var ControlledPollAction = struct {
 	/**
 	 * Abort the current polling operation and do not advance the position for this fragment.
@@ -59,23 +55,22 @@ var ControlledPollAction = struct {
 }
 
 type Image struct {
-	termBuffers [logbuffer.PartitionCount]*atomic.Buffer
-	header      logbuffer.Header
-
+	sourceIdentity     string
+	logBuffers         *logbuffer.LogBuffers
+	exceptionHandler   func(error)
+	termBuffers        [logbuffer.PartitionCount]*atomic.Buffer
 	subscriberPosition Position
+	header             logbuffer.Header
+	isClosed           atomic.Bool
+	isEos              bool
 
-	logBuffers *logbuffer.LogBuffers
-
-	sourceIdentity string
-	isClosed       atomic.Bool
-
-	exceptionHandler func(error)
-
-	correlationID              int64
-	subscriptionRegistrationID int64
-	sessionID                  int32
 	termLengthMask             int32
 	positionBitsToShift        uint8
+	sessionID                  int32
+	joinPosition               int64
+	finalPosition              int64
+	subscriptionRegistrationID int64
+	correlationID              int64
 }
 
 // NewImage wraps around provided LogBuffers setting up the structures for polling
@@ -105,36 +100,62 @@ func (image *Image) IsClosed() bool {
 }
 
 func (image *Image) Poll(handler term.FragmentHandler, fragmentLimit int) int {
-
-	result := ImageClosed
-
-	if !image.IsClosed() {
-		position := image.subscriberPosition.get()
-		termOffset := int32(position) & image.termLengthMask
-		index := indexByPosition(position, image.positionBitsToShift)
-		termBuffer := image.termBuffers[index]
-
-		var offset int32
-		offset, result = term.Read(termBuffer, termOffset, handler, fragmentLimit, &image.header)
-
-		newPosition := position + int64(offset-termOffset)
-		if newPosition > position {
-			image.subscriberPosition.set(newPosition)
-		}
+	if image.IsClosed() {
+		return 0
 	}
 
+	position := image.subscriberPosition.get()
+	termOffset := int32(position) & image.termLengthMask
+	index := indexByPosition(position, image.positionBitsToShift)
+	termBuffer := image.termBuffers[index]
+
+	offset, result := term.Read(termBuffer, termOffset, handler, fragmentLimit, &image.header)
+
+	newPosition := position + int64(offset-termOffset)
+	if newPosition > position {
+		image.subscriberPosition.set(newPosition)
+	}
 	return result
 }
 
 // Position returns the position this Image has been consumed to by the subscriber.
 func (image *Image) Position() int64 {
+	if image.IsClosed() {
+		return image.finalPosition
+	}
 	return image.subscriberPosition.get()
+}
+
+// IsEndOfStream returns if the current consumed position at the end of the stream?
+func (image *Image) IsEndOfStream() bool {
+	if image.IsClosed() {
+		return image.isEos
+	}
+	return image.subscriberPosition.get() >= image.logBuffers.Meta().EndOfStreamPosOff.Get()
+}
+
+// SessionID returns the sessionId for the steam of messages.
+func (image *Image) SessionID() int32 {
+	return image.sessionID
+}
+
+// CorrelationID returns the correlationId for identification of the image with the media driver.
+func (image *Image) CorrelationID() int64 {
+	return image.correlationID
+}
+
+// SubscriptionRegistrationID returns the registrationId for the Subscription of the Image.
+func (image *Image) SubscriptionRegistrationID() int64 {
+	return image.subscriptionRegistrationID
 }
 
 // Close the image and mappings. The image becomes unusable after closing.
 func (image *Image) Close() error {
 	var err error
 	if image.isClosed.CompareAndSet(false, true) {
+		image.finalPosition = image.subscriberPosition.get()
+		image.isEos = image.finalPosition >=
+			image.logBuffers.Meta().EndOfStreamPosOff.Get()
 		logger.Debugf("Closing %v", image)
 		err = image.logBuffers.Close()
 	}

--- a/aeron/logbuffer/FrameDescriptor.go
+++ b/aeron/logbuffer/FrameDescriptor.go
@@ -53,6 +53,10 @@ func typeOffset(frameOffset int32) int32 {
 	return frameOffset + DataFrameHeader.TypeFieldOffset
 }
 
+func reservedValueOffset(frameOffset int32) int32 {
+	return frameOffset + DataFrameHeader.ReservedValueFieldOffset
+}
+
 func GetFlags(logBuffer *atomic.Buffer, frameOffset int32) uint8 {
 	offset := flagsOffset(frameOffset)
 	return logBuffer.GetUInt8(offset)
@@ -76,6 +80,11 @@ func GetStreamId(logBuffer *atomic.Buffer, frameOffset int32) int32 {
 func GetFrameLength(logBuffer *atomic.Buffer, frameOffset int32) int32 {
 	offset := lengthOffset(frameOffset)
 	return logBuffer.GetInt32Volatile(offset)
+}
+
+func GetReservedValue(logBuffer *atomic.Buffer, frameOffset int32) int64 {
+	offset := reservedValueOffset(frameOffset)
+	return logBuffer.GetInt64Volatile(offset)
 }
 
 func SetFrameLength(logBuffer *atomic.Buffer, frameOffset int32, frameLength int32) {

--- a/aeron/logbuffer/header.go
+++ b/aeron/logbuffer/header.go
@@ -66,6 +66,10 @@ func (hdr *Header) StreamId() int32 {
 	return GetStreamId(&hdr.buffer, hdr.offset)
 }
 
+func (hdr *Header) GetReservedValue() int64 {
+	return GetReservedValue(&hdr.buffer, hdr.offset)
+}
+
 func (hdr *Header) SetOffset(offset int32) *Header {
 	hdr.offset = offset
 	return hdr
@@ -82,6 +86,11 @@ func (hdr *Header) SetInitialTermID(initialTermID int32) *Header {
 
 func (hdr *Header) SetPositionBitsToShift(positionBitsToShift int32) *Header {
 	hdr.positionBitsToShift = positionBitsToShift
+	return hdr
+}
+
+func (hdr *Header) SetReservedValue(reservedValue int64) *Header {
+	hdr.buffer.PutInt64(reservedValueOffset(hdr.offset), reservedValue)
 	return hdr
 }
 

--- a/aeron/logbuffer/logbuffers_test.go
+++ b/aeron/logbuffer/logbuffers_test.go
@@ -126,6 +126,23 @@ func TestLogBuffers_BufferFail(t *testing.T) {
 	t.Fail()
 }
 
+func TestHeader_ReservedValue(t *testing.T) {
+	bytes := make([]byte, 1000)
+	buffer := atomic.MakeBuffer(bytes)
+	if buffer.Capacity() != 1000 {
+		t.Error("Buffer capacity should be 1000")
+	}
+	var header Header
+	header.Wrap(buffer.Ptr(), 1000)
+	if header.GetReservedValue() != 0 {
+		t.Error("Reserved value should be 0")
+	}
+	header.SetReservedValue(123)
+	if header.GetReservedValue() != 123 {
+		t.Error("Reserved value should be 123")
+	}
+}
+
 func TestLogBuffers_Meta(t *testing.T) {
 	defer func() {
 		if err := recover(); err != nil {

--- a/aeron/publication.go
+++ b/aeron/publication.go
@@ -70,7 +70,7 @@ func NewPublication(logBuffers *logbuffer.LogBuffers) *Publication {
 	pub.initialTermID = pub.metaData.InitTermID.Get()
 	pub.maxPayloadLength = pub.metaData.MTULen.Get() - logbuffer.DataFrameHeader.Length
 	pub.maxMessageLength = logbuffer.ComputeMaxMessageLength(termBufferCapacity)
-	pub.positionBitsToShift = int32(util.NumberOfTrailingZeroes(termBufferCapacity))
+	pub.positionBitsToShift = int32(util.NumberOfTrailingZeroes(uint32(termBufferCapacity)))
 	pub.maxPossiblePosition = int64(termBufferCapacity) * (1 << 31)
 
 	pub.isClosed.Set(false)

--- a/aeron/publication_test.go
+++ b/aeron/publication_test.go
@@ -18,6 +18,7 @@ package aeron
 
 import (
 	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/util"
 	"github.com/lirm/aeron-go/aeron/counters"
 	"github.com/lirm/aeron-go/aeron/driver"
 	"github.com/lirm/aeron-go/aeron/logbuffer"
@@ -79,6 +80,21 @@ func prepareCnc(t *testing.T) (string, *counters.MetaDataFlyweight) {
 	t.Logf("meta data: %v", meta)
 
 	return counterFileName, &meta
+}
+
+func TestNumberOfZeros(t *testing.T) {
+	if x := util.NumberOfTrailingZeroes(65536); x != 16 {
+		t.Logf("trailing zeroes: %d", x)
+		t.Fail()
+	}
+	if x := util.NumberOfTrailingZeroes(131072); x != 17 {
+		t.Logf("trailing zeroes: %d", x)
+		t.Fail()
+	}
+	if x := util.NumberOfTrailingZeroes(4194304); x != 22 {
+		t.Logf("trailing zeroes: %d", x)
+		t.Fail()
+	}
 }
 
 func TestNewPublication(t *testing.T) {

--- a/aeron/subscription.go
+++ b/aeron/subscription.go
@@ -129,6 +129,11 @@ func (sub *Subscription) removeImage(correlationID int64) *Image {
 	return nil
 }
 
+// RegistrationID returns the registration id.
+func (sub *Subscription) RegistrationID() int64 {
+	return sub.registrationID
+}
+
 // HasImages is a helper method checking whether this subscription has any images associated with it.
 func (sub *Subscription) HasImages() bool {
 	images := sub.images.Get()

--- a/aeron/subscription.go
+++ b/aeron/subscription.go
@@ -135,6 +135,23 @@ func (sub *Subscription) HasImages() bool {
 	return len(images) > 0
 }
 
+// ImageCount count of images associated with this subscription.
+func (sub *Subscription) ImageCount() int {
+	images := sub.images.Get()
+	return len(images)
+}
+
+// ImageBySessionId returns the associated with the given sessionId.
+func (sub *Subscription) ImageBySessionID(sessionID int32) *Image {
+	img := sub.images.Get()
+	for _, image := range img {
+		if image.sessionID == sessionID {
+			return &image
+		}
+	}
+	return nil
+}
+
 // IsConnectedTo is a helper function used primarily by tests, which is used within the same process to verify that
 // subscription is connected to a specific publication.
 func IsConnectedTo(sub *Subscription, pub *Publication) bool {

--- a/aeron/util/bits.go
+++ b/aeron/util/bits.go
@@ -41,7 +41,7 @@ func AlignInt32(value, alignment int32) int32 {
 }
 
 // NumberOfTrailingZeroes is HD recipe for determining the number of leading zeros on 32 bit integer
-func NumberOfTrailingZeroes(value int32) uint8 {
+func NumberOfTrailingZeroes(value uint32) uint8 {
 	table := [32]uint8{
 		0, 1, 2, 24, 3, 19, 6, 25,
 		22, 4, 20, 10, 16, 7, 12, 26,

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/lirm/aeron-go
+
+go 1.12
+
+require (
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+	github.com/edsrzf/mmap-go v1.0.0
+	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/sys v0.0.0-20190609082536-301114b31cce // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,15 @@
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sys v0.0.0-20190609082536-301114b31cce h1:CQakrGkKbydnUmt7cFIlmQ4lNQiqdTPt6xzXij4nYCc=
 golang.org/x/sys v0.0.0-20190609082536-301114b31cce/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
+github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20190609082536-301114b31cce h1:CQakrGkKbydnUmt7cFIlmQ4lNQiqdTPt6xzXij4nYCc=
+golang.org/x/sys v0.0.0-20190609082536-301114b31cce/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This adds Go 1.12 modules support, bug fixes, and extra idle strategies and a ChannelUri parser.

The biggest fix here is to fix number of trailing zeros to take unsigned ints. Without this fix, some term buffer lengths would lead to crashes.