### PR TITLE
Fix a bug where a subscription with multiple images does not release

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -442,11 +442,12 @@ func (cc *ClientConductor) releaseSubscription(regID int64, images []Image) {
 			cc.subs[subcnt-1] = nil
 			subcnt--
 
-			for _, image := range images {
+			for i := range images {
+				image := &images[i]
 				if cc.onUnavailableImageHandler != nil {
-					cc.onUnavailableImageHandler(&image)
+					cc.onUnavailableImageHandler(image)
 				}
-				cc.lingeringResources <- lingerResourse{now, &image}
+				cc.lingeringResources <- lingerResourse{now, image}
 			}
 		}
 	}


### PR DESCRIPTION
We pass a pointer to the loop variable here, so only the last image is ever released.