### PR TITLE
Fix publication close leak

### DIFF
--- a/aeron/logbuffer/header.go
+++ b/aeron/logbuffer/header.go
@@ -94,6 +94,11 @@ func (hdr *Header) SetReservedValue(reservedValue int64) *Header {
 	return hdr
 }
 
+func (hdr *Header) SetSessionId(value int32) *Header {
+	hdr.buffer.PutInt32(sessionIdOffset(hdr.offset), value)
+	return hdr
+}
+
 // computePosition computes the current position in absolute number of bytes.
 func computePosition(activeTermId int32, termOffset int32, positionBitsToShift int32, initialTermId int32) int64 {
 	termCount := activeTermId - initialTermId // copes with negative activeTermId on rollover

--- a/aeron/logbuffer/logbuffers.go
+++ b/aeron/logbuffer/logbuffers.go
@@ -30,6 +30,7 @@ type LogBuffers struct {
 	mmapFiles []*memmap.File
 	buffers   [PartitionCount + 1]atomic.Buffer
 	meta      LogBufferMetaData
+	refCount  int
 }
 
 // Wrap is the factory method wrapping the LogBuffers structure around memory mapped file
@@ -120,4 +121,16 @@ func (logBuffers *LogBuffers) Close() error {
 	}
 	logBuffers.mmapFiles = nil
 	return err
+}
+
+// IncRef increments the reference count. Returns the current reference count after increment.
+func (logBuffers *LogBuffers) IncRef() int {
+	logBuffers.refCount++
+	return logBuffers.refCount
+}
+
+// DecRef decrements the reference count. Returns the current reference counter after decrement.
+func (logBuffers *LogBuffers) DecRef() int {
+	logBuffers.refCount--
+	return logBuffers.refCount
 }


### PR DESCRIPTION
Fix a leak when closing publications. 

There was also an issue here where cached publications were being returned when adding a new exclusive publication that was inconsistent with the other implementations: two exclusive publications, even on the same Aeron client, channel, stream ID, should give back two different registration IDs and will have two different session IDs. More about that here: https://aeroncookbook.com/aeron/aeron-channel-stream-session/

Also add Header.SetSessionId.