### PR TITLE
Add additional nil checks to ClientConductor.Close.

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -174,7 +174,7 @@ func (cc *ClientConductor) Close() error {
 	var err error
 	if cc.running.CompareAndSet(true, false) {
 		for _, pub := range cc.pubs {
-			if pub.publication != nil {
+			if pub != nil && pub.publication != nil {
 				err = pub.publication.Close()
 				if err != nil {
 					cc.errorHandler(err)
@@ -183,7 +183,7 @@ func (cc *ClientConductor) Close() error {
 		}
 
 		for _, sub := range cc.subs {
-			if sub.subscription != nil {
+			if sub != nil && sub.subscription != nil {
 				err = sub.subscription.Close()
 				if err != nil {
 					cc.errorHandler(err)


### PR DESCRIPTION
Related to https://github.com/lirm/aeron-go/commit/03da701f5a2e771f90723fca8a35ad2e63c4e880.

Since the underlying slice changes during iteration (through calls to releasePublication/releaseSubscription), the iteration could run into a nil value set by https://github.com/lirm/aeron-go/blob/083126fdd27fc47191e3d5cd9bc8f0e0932e980b/aeron/clientconductor.go#L437.