### PR TITLE
counter reader Scan - counterId bug fix

### DIFF
--- a/aeron/counters/reader.go
+++ b/aeron/counters/reader.go
@@ -73,8 +73,7 @@ func (reader *Reader) Scan(cb func(Counter)) {
 			//fmt.Printf("Reading at offset %d; counterState=%d; typeId=%d\n", i, recordStatus, typeId)
 
 			cb(Counter{id, typeId, value, label})
-
-			id++
 		}
+		id++
 	}
 }


### PR DESCRIPTION
Scan would skip counter entries with RECLAIMED (-1) recordStatus, but not increment id.
Thus, any subsequent counters would be reported with incorrect Id values.