### PR TITLE
forward error handler to client conductor

### DIFF
--- a/aeron/aeron.go
+++ b/aeron/aeron.go
@@ -88,6 +88,8 @@ func Connect(ctx *Context) (*Aeron, error) {
 	aeron.conductor.onNewPublicationHandler = ctx.newPublicationHandler
 	aeron.conductor.onNewSubscriptionHandler = ctx.newSubscriptionHandler
 
+	aeron.conductor.errorHandler = ctx.errorHandler
+
 	aeron.conductor.Start(ctx.idleStrategy)
 
 	return aeron, nil


### PR DESCRIPTION
Client conductor panics when hitting an undefined error handler. There is no way to set `ClientConductor.errorHandler` from what I can tell. One way to hit this is to force an InterServiceTimeout by sleeping the running computer.

I just forwarded the context error callback similar to the other callbacks. Another approach is to if guard every errorHandler invocation.

```
2022-08-04T21:44:00.756Z	error	aeron	aeron/clientconductor.go:596	OnClientTimeout for ClientID:3
github.com/lirm/aeron-go/aeron.(*ClientConductor).OnClientTimeout
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:596
github.com/lirm/aeron-go/aeron/driver.(*ListenerAdapter).ReceiveMessages.func1
	external/com_github_lirm_aeron_go/aeron/driver/listeneradapter.go:217
github.com/lirm/aeron-go/aeron/broadcast.(*CopyReceiver).Receive
	external/com_github_lirm_aeron_go/aeron/broadcast/copyreceiver.go:64
github.com/lirm/aeron-go/aeron/driver.(*ListenerAdapter).ReceiveMessages
	external/com_github_lirm_aeron_go/aeron/driver/listeneradapter.go:223
github.com/lirm/aeron-go/aeron.(*ClientConductor).run
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:243
2022/08/04 21:44:00 onInterServiceTimeout: now=1659649440758078037
2022-08-04T21:44:05.761Z	warn	aeron	aeron/clientconductor.go:205	failed to stop conductor after 5s
2022-08-04T21:44:05.761Z	warn	aeron	aeron/clientconductor.go:717	Failed to close client conductor: failed to stop conductor after 5s
2022-08-04T21:44:05.761Z	error	aeron	aeron/clientconductor.go:233	Panic: runtime error: invalid memory address or nil pointer dereference
github.com/lirm/aeron-go/aeron.(*ClientConductor).run.func1
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:233
runtime.gopanic
	GOROOT/src/runtime/panic.go:1047
runtime.panicmem
	GOROOT/src/runtime/panic.go:221
runtime.sigpanic
	GOROOT/src/runtime/signal_unix.go:735
github.com/lirm/aeron-go/aeron.(*ClientConductor).onInterServiceTimeout
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:718
github.com/lirm/aeron-go/aeron.(*ClientConductor).onHeartbeatCheckTimeouts
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:728
github.com/lirm/aeron-go/aeron.(*ClientConductor).run
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:244
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x68f0bb]

goroutine 18 [running, locked to thread]:
github.com/lirm/aeron-go/aeron.(*ClientConductor).run.func1()
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:234 +0x19b
panic({0x8ec4a0, 0xcf9630})
	GOROOT/src/runtime/panic.go:1047 +0x266
github.com/lirm/aeron-go/aeron.(*ClientConductor).onInterServiceTimeout(0xc0003de148, 0x1708425f880f9a55)
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:718 +0x1bb
github.com/lirm/aeron-go/aeron.(*ClientConductor).onHeartbeatCheckTimeouts(0xc0003de148)
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:728 +0xaa
github.com/lirm/aeron-go/aeron.(*ClientConductor).run(0xc0003de148, {0x9e5ea0, 0xc0000c4e80})
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:244 +0x19c
created by github.com/lirm/aeron-go/aeron.(*ClientConductor).Start
	external/com_github_lirm_aeron_go/aeron/clientconductor.go:216 +0xdd
```