### PR TITLE
Fix archive to use wildcard port responses and bug in replay merge

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -664,6 +664,27 @@ func (cc *ClientConductor) OnOperationSuccess(corrID int64) {
 
 }
 
+func (cc *ClientConductor) OnChannelEndpointError(corrID int64, errorMessage string) {
+	logger.Debugf("OnChannelEndpointError: correlationID=%d, errorMessage=%s", corrID, errorMessage)
+
+	cc.adminLock.Lock()
+	defer cc.adminLock.Unlock()
+
+	statusIndicatorId := int32(corrID)
+
+	for _, pubDef := range cc.pubs {
+		if pubDef.publication != nil && pubDef.publication.ChannelStatusID() == statusIndicatorId {
+			cc.onError(fmt.Errorf(errorMessage))
+		}
+	}
+
+	for _, subDef := range cc.subs {
+		if subDef.subscription != nil && subDef.subscription.ChannelStatusId() == statusIndicatorId {
+			cc.onError(fmt.Errorf(errorMessage))
+		}
+	}
+}
+
 func (cc *ClientConductor) OnErrorResponse(corrID int64, errorCode int32, errorMessage string) {
 	logger.Debugf("OnErrorResponse: correlationID=%d, errorCode=%d, errorMessage=%s", corrID, errorCode, errorMessage)
 
@@ -679,7 +700,7 @@ func (cc *ClientConductor) OnErrorResponse(corrID int64, errorCode int32, errorM
 		}
 	}
 
-	for _, subDef := range cc.pubs {
+	for _, subDef := range cc.subs {
 		if subDef.regID == corrID {
 			subDef.status = RegistrationStatus.ErroredMediaDriver
 			subDef.errorCode = errorCode

--- a/aeron/command/control.go
+++ b/aeron/command/control.go
@@ -46,6 +46,20 @@ const (
 	AddRcvDestination = 0x0c
 	// RemoveRcvDestination removes a Destination for existing Subscription.
 	RemoveRcvDestination = 0x0D
-	// RecordingPosition is rhe position a recording has reached when being archived
-	RecordingPosition = 0x64 // 100
+)
+
+const (
+	ErrorCodeUnknownCodeValue               = -1
+	ErrorCodeUnused                         = 0
+	ErrorCodeInvalidChannel                 = 1
+	ErrorCodeUnknownSubscription            = 2
+	ErrorCodeUnknownPublication             = 3
+	ErrorCodeChannelEndpointError           = 4
+	ErrorCodeUnknownCounter                 = 5
+	ErrorCodeUnknownCommandTypeID           = 6
+	ErrorCodeMalformedCommand               = 7
+	ErrorCodeNotSupported                   = 8
+	ErrorCodeUnknownHost                    = 9
+	ErrorCodeResourceTemporarilyUnavailable = 10
+	ErrorCodeGenericError                   = 11
 )

--- a/archive/examples/basic_recording_publisher/basic_recording_publisher.go
+++ b/archive/examples/basic_recording_publisher/basic_recording_publisher.go
@@ -62,7 +62,7 @@ func main() {
 	}
 	defer arch.Close()
 
-	channel := *examples.Config.SampleChannel + "|ssc=true"
+	channel := *examples.Config.MdcChannel + "|ssc=true"
 	stream := int32(*examples.Config.SampleStream)
 
 	if _, err := arch.StartRecording(channel, stream, true, true); err != nil {

--- a/archive/examples/basic_replay_merge/basic_replay_merge.go
+++ b/archive/examples/basic_replay_merge/basic_replay_merge.go
@@ -37,7 +37,7 @@ var logger = logging.MustGetLogger(logID)
 func main() {
 	flag.Parse()
 
-	sampleChannel := *examples.Config.SampleChannel
+	sampleChannel := *examples.Config.MdcChannel
 	sampleStream := int32(*examples.Config.SampleStream)
 	responseStream := sampleStream + 2
 
@@ -145,6 +145,8 @@ func main() {
 		arch.RecordingEventsPoll()
 		idleStrategy.Idle(fragmentsRead)
 	}
+
+	merge.Close()
 
 	for {
 		fragmentsRead := subscription.Poll(printHandler, 10)

--- a/archive/examples/examplesconfig.go
+++ b/archive/examples/examplesconfig.go
@@ -28,6 +28,7 @@ var Config = struct {
 	ResponseChannel *string
 	SampleStream    *int
 	SampleChannel   *string
+	MdcChannel      *string
 	AeronPrefix     *string
 	ProfilerEnabled *bool
 	DriverTimeout   *int64
@@ -38,9 +39,10 @@ var Config = struct {
 	flag.Int("requeststream", 10, "default request control stream to use"),
 	flag.String("requestchannel", "aeron:udp?endpoint=localhost:8010", "default request control channel to publish to"),
 	flag.Int("responsestream", 21, "default response control stream to use"),
-	flag.String("responsechannel", "aeron:udp?endpoint=localhost:8020", "default response control channel to publish to"),
+	flag.String("responsechannel", "aeron:udp?endpoint=localhost:0", "default response control channel to publish to"),
 	flag.Int("samplestream", 1001, "default response control stream to use"),
 	flag.String("samplechannel", "aeron:udp?endpoint=localhost:20121", "default response control channel to publish to"),
+	flag.String("mdcchannel", "aeron:udp?control=localhost:20121", "default response control channel to publish to"),
 	flag.String("prefix", aeron.DefaultAeronDir+"/aeron-"+aeron.UserName, "root directory for aeron driver file"),
 	flag.Bool("profile", false, "enable CPU profiling"),
 	flag.Int64("timeout", 10000, "driver liveliness timeout in ms"),

--- a/archive/options.go
+++ b/archive/options.go
@@ -50,7 +50,7 @@ type Options struct {
 var defaultOptions = Options{
 	RequestChannel:         "aeron:udp?endpoint=localhost:8010",
 	RequestStream:          10,
-	ResponseChannel:        "aeron:udp?endpoint=localhost:8020",
+	ResponseChannel:        "aeron:udp?endpoint=localhost:0",
 	ResponseStream:         20,
 	RecordingEventsChannel: "aeron:udp?control-mode=dynamic|control=localhost:8030",
 	RecordingEventsStream:  30,

--- a/archive/replaymerge/replaymerge.go
+++ b/archive/replaymerge/replaymerge.go
@@ -290,10 +290,10 @@ func (rm *ReplayMerge) getRecordingPosition(nowMs int64) (workCount int, err err
 		return
 	}
 	if success {
-		nextTargetPosition := rm.polledRelevantId()
+		rm.nextTargetPosition = rm.polledRelevantId()
 		rm.activeCorrelationId = aeron.NullValue
 
-		if archive.RecordingPositionNull == nextTargetPosition {
+		if archive.RecordingPositionNull == rm.nextTargetPosition {
 			correlationId := rm.archive.Aeron().NextCorrelationID()
 
 			if rm.archive.Proxy.StopPositionRequest(correlationId, rm.recordingId) == nil {


### PR DESCRIPTION
Also add better support for OnChannelEndpointError, though this method varies in behavior depending on whether you're connected to Java or C media drivers. Error handling in ClientConductor needs cleanup.