### PR TITLE
Fix replay merge, use wildcard ports for archive responses, and fix PollForDescriptors

### DIFF
--- a/aeron/atomic/buffer.go
+++ b/aeron/atomic/buffer.go
@@ -85,6 +85,7 @@ func MakeBuffer(args ...interface{}) *Buffer {
 }
 
 // Wrap raw memory with this buffer instance
+//go:norace
 func (buf *Buffer) Wrap(buffer unsafe.Pointer, length int32) *Buffer {
 	buf.bufferPtr = buffer
 	buf.length = length
@@ -92,17 +93,20 @@ func (buf *Buffer) Wrap(buffer unsafe.Pointer, length int32) *Buffer {
 }
 
 // Ptr will return the raw memory pointer for the underlying buffer
+//go:norace
 func (buf *Buffer) Ptr() unsafe.Pointer {
 	return buf.bufferPtr
 }
 
 // Capacity of the buffer, which is used for bound checking
+//go:norace
 func (buf *Buffer) Capacity() int32 {
 	return buf.length
 }
 
 // Fill the buffer with the value of the argument byte. Generally used for initialization,
 // since it's somewhat expensive.
+//go:norace
 func (buf *Buffer) Fill(b uint8) {
 	if buf.length == 0 {
 		return
@@ -113,6 +117,7 @@ func (buf *Buffer) Fill(b uint8) {
 	}
 }
 
+//go:norace
 func (buf *Buffer) GetUInt8(offset int32) uint8 {
 	BoundsCheck(offset, 1, buf.length)
 
@@ -121,6 +126,7 @@ func (buf *Buffer) GetUInt8(offset int32) uint8 {
 	return *(*uint8)(uptr)
 }
 
+//go:norace
 func (buf *Buffer) GetUInt16(offset int32) uint16 {
 	BoundsCheck(offset, 2, buf.length)
 
@@ -129,6 +135,7 @@ func (buf *Buffer) GetUInt16(offset int32) uint16 {
 	return *(*uint16)(uptr)
 }
 
+//go:norace
 func (buf *Buffer) GetInt32(offset int32) int32 {
 	BoundsCheck(offset, 4, buf.length)
 
@@ -137,6 +144,7 @@ func (buf *Buffer) GetInt32(offset int32) int32 {
 	return *(*int32)(uptr)
 }
 
+//go:norace
 func (buf *Buffer) GetInt64(offset int32) int64 {
 	BoundsCheck(offset, 8, buf.length)
 
@@ -145,6 +153,7 @@ func (buf *Buffer) GetInt64(offset int32) int64 {
 	return *(*int64)(uptr)
 }
 
+//go:norace
 func (buf *Buffer) PutUInt8(offset int32, value uint8) {
 	BoundsCheck(offset, 1, buf.length)
 
@@ -153,6 +162,7 @@ func (buf *Buffer) PutUInt8(offset int32, value uint8) {
 	*(*uint8)(uptr) = value
 }
 
+//go:norace
 func (buf *Buffer) PutInt8(offset int32, value int8) {
 	BoundsCheck(offset, 1, buf.length)
 
@@ -161,6 +171,7 @@ func (buf *Buffer) PutInt8(offset int32, value int8) {
 	*(*int8)(uptr) = value
 }
 
+//go:norace
 func (buf *Buffer) PutUInt16(offset int32, value uint16) {
 	BoundsCheck(offset, 2, buf.length)
 
@@ -169,6 +180,7 @@ func (buf *Buffer) PutUInt16(offset int32, value uint16) {
 	*(*uint16)(uptr) = value
 }
 
+//go:norace
 func (buf *Buffer) PutInt32(offset int32, value int32) {
 	BoundsCheck(offset, 4, buf.length)
 
@@ -177,6 +189,7 @@ func (buf *Buffer) PutInt32(offset int32, value int32) {
 	*(*int32)(uptr) = value
 }
 
+//go:norace
 func (buf *Buffer) PutInt64(offset int32, value int64) {
 	BoundsCheck(offset, 8, buf.length)
 
@@ -185,6 +198,7 @@ func (buf *Buffer) PutInt64(offset int32, value int64) {
 	*(*int64)(uptr) = value
 }
 
+//go:norace
 func (buf *Buffer) GetAndAddInt64(offset int32, delta int64) int64 {
 	BoundsCheck(offset, 8, buf.length)
 
@@ -194,6 +208,7 @@ func (buf *Buffer) GetAndAddInt64(offset int32, delta int64) int64 {
 	return int64(newVal) - delta
 }
 
+//go:norace
 func (buf *Buffer) GetInt32Volatile(offset int32) int32 {
 	BoundsCheck(offset, 4, buf.length)
 
@@ -203,6 +218,7 @@ func (buf *Buffer) GetInt32Volatile(offset int32) int32 {
 	return int32(cur)
 }
 
+//go:norace
 func (buf *Buffer) GetInt64Volatile(offset int32) int64 {
 	BoundsCheck(offset, 8, buf.length)
 
@@ -212,6 +228,7 @@ func (buf *Buffer) GetInt64Volatile(offset int32) int64 {
 	return int64(cur)
 }
 
+//go:norace
 func (buf *Buffer) PutInt64Ordered(offset int32, value int64) {
 	BoundsCheck(offset, 8, buf.length)
 
@@ -219,6 +236,7 @@ func (buf *Buffer) PutInt64Ordered(offset int32, value int64) {
 	atomic.StoreInt64((*int64)(uptr), value)
 }
 
+//go:norace
 func (buf *Buffer) PutInt32Ordered(offset int32, value int32) {
 	BoundsCheck(offset, 4, buf.length)
 
@@ -226,6 +244,7 @@ func (buf *Buffer) PutInt32Ordered(offset int32, value int32) {
 	atomic.StoreInt32((*int32)(uptr), value)
 }
 
+//go:norace
 func (buf *Buffer) PutIntOrdered(offset int32, value int) {
 	BoundsCheck(offset, 4, buf.length)
 
@@ -233,6 +252,7 @@ func (buf *Buffer) PutIntOrdered(offset int32, value int) {
 	atomic.StoreInt32((*int32)(uptr), int32(value))
 }
 
+//go:norace
 func (buf *Buffer) CompareAndSetInt64(offset int32, expectedValue, updateValue int64) bool {
 	BoundsCheck(offset, 8, buf.length)
 
@@ -240,6 +260,7 @@ func (buf *Buffer) CompareAndSetInt64(offset int32, expectedValue, updateValue i
 	return atomic.CompareAndSwapInt64((*int64)(uptr), expectedValue, updateValue)
 }
 
+//go:norace
 func (buf *Buffer) CompareAndSetInt32(offset int32, expectedValue, updateValue int32) bool {
 	BoundsCheck(offset, 4, buf.length)
 
@@ -247,6 +268,7 @@ func (buf *Buffer) CompareAndSetInt32(offset int32, expectedValue, updateValue i
 	return atomic.CompareAndSwapInt32((*int32)(uptr), expectedValue, updateValue)
 }
 
+//go:norace
 func (buf *Buffer) PutBytes(index int32, srcBuffer *Buffer, srcint32 int32, length int32) {
 	BoundsCheck(index, length, buf.length)
 	BoundsCheck(srcint32, length, srcBuffer.length)
@@ -254,6 +276,7 @@ func (buf *Buffer) PutBytes(index int32, srcBuffer *Buffer, srcint32 int32, leng
 	util.Memcpy(uintptr(buf.bufferPtr)+uintptr(index), uintptr(srcBuffer.bufferPtr)+uintptr(srcint32), length)
 }
 
+//go:norace
 func (buf *Buffer) GetBytesArray(offset int32, length int32) []byte {
 	BoundsCheck(offset, length, buf.length)
 
@@ -266,6 +289,7 @@ func (buf *Buffer) GetBytesArray(offset int32, length int32) []byte {
 	return bArr
 }
 
+//go:norace
 func (buf *Buffer) GetBytes(offset int32, b []byte) {
 	length := len(b)
 	BoundsCheck(offset, int32(length), buf.length)
@@ -278,6 +302,7 @@ func (buf *Buffer) GetBytes(offset int32, b []byte) {
 
 // WriteBytes writes data from offset and length to the given dest buffer. This will
 // grow the buffer as needed.
+//go:norace
 func (buf *Buffer) WriteBytes(dest *bytes.Buffer, offset int32, length int32) {
 	BoundsCheck(offset, length, buf.length)
 	// grow the buffer all at once to prevent additional allocations.
@@ -288,6 +313,7 @@ func (buf *Buffer) WriteBytes(dest *bytes.Buffer, offset int32, length int32) {
 	}
 }
 
+//go:norace
 func (buf *Buffer) PutBytesArray(index int32, arr *[]byte, srcint32 int32, length int32) {
 	BoundsCheck(index, length, buf.length)
 	BoundsCheck(srcint32, length, int32(len(*arr)))
@@ -299,6 +325,7 @@ func (buf *Buffer) PutBytesArray(index int32, arr *[]byte, srcint32 int32, lengt
 
 // BoundsCheck is helper function to make sure buffer writes and reads to
 // not go out of bounds on stated buffer capacity
+//go:norace
 func BoundsCheck(index int32, length int32, myLength int32) {
 	if (index + length) > myLength {
 		log.Fatal(fmt.Sprintf("Out of Bounds. int32: %d + %d Capacity: %d", index, length, myLength))

--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -607,6 +607,7 @@ func (cc *ClientConductor) OnSubscriptionReady(correlationID int64, channelStatu
 
 }
 
+//go:norace
 func (cc *ClientConductor) OnAvailableImage(streamID int32, sessionID int32, logFilename string, sourceIdentity string,
 	subscriberPositionID int32, subsRegID int64, corrID int64) {
 	logger.Debugf("OnAvailableImage: streamId=%d, sessionId=%d, logFilename=%s, sourceIdentity=%s, subsRegID=%d, corrID=%d",

--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -182,8 +182,12 @@ func (cc *ClientConductor) Close() (err error) {
 
 	now := time.Now().UnixNano()
 
+	running := cc.running.Get()
+
 	cc.closeAllResources(now)
-	cc.driverProxy.ClientClose()
+	if running {
+		cc.driverProxy.ClientClose()
+	}
 
 	timeoutDuration := 5 * time.Second
 	timeout := time.Now().Add(timeoutDuration)

--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -669,6 +669,27 @@ func (cc *ClientConductor) OnOperationSuccess(corrID int64) {
 
 }
 
+func (cc *ClientConductor) OnChannelEndpointError(corrID int64, errorMessage string) {
+	logger.Debugf("OnChannelEndpointError: correlationID=%d, errorMessage=%s", corrID, errorMessage)
+
+	cc.adminLock.Lock()
+	defer cc.adminLock.Unlock()
+
+	statusIndicatorId := int32(corrID)
+
+	for _, pubDef := range cc.pubs {
+		if pubDef.publication != nil && pubDef.publication.ChannelStatusID() == statusIndicatorId {
+			cc.onError(fmt.Errorf(errorMessage))
+		}
+	}
+
+	for _, subDef := range cc.subs {
+		if subDef.subscription != nil && subDef.subscription.ChannelStatusId() == statusIndicatorId {
+			cc.onError(fmt.Errorf(errorMessage))
+		}
+	}
+}
+
 func (cc *ClientConductor) OnErrorResponse(corrID int64, errorCode int32, errorMessage string) {
 	logger.Debugf("OnErrorResponse: correlationID=%d, errorCode=%d, errorMessage=%s", corrID, errorCode, errorMessage)
 
@@ -684,7 +705,7 @@ func (cc *ClientConductor) OnErrorResponse(corrID int64, errorCode int32, errorM
 		}
 	}
 
-	for _, subDef := range cc.pubs {
+	for _, subDef := range cc.subs {
 		if subDef.regID == corrID {
 			subDef.status = RegistrationStatus.ErroredMediaDriver
 			subDef.errorCode = errorCode

--- a/aeron/command/control.go
+++ b/aeron/command/control.go
@@ -46,6 +46,20 @@ const (
 	AddRcvDestination = 0x0c
 	// RemoveRcvDestination removes a Destination for existing Subscription.
 	RemoveRcvDestination = 0x0D
-	// RecordingPosition is rhe position a recording has reached when being archived
-	RecordingPosition = 0x64 // 100
+)
+
+const (
+	ErrorCodeUnknownCodeValue               = -1
+	ErrorCodeUnused                         = 0
+	ErrorCodeInvalidChannel                 = 1
+	ErrorCodeUnknownSubscription            = 2
+	ErrorCodeUnknownPublication             = 3
+	ErrorCodeChannelEndpointError           = 4
+	ErrorCodeUnknownCounter                 = 5
+	ErrorCodeUnknownCommandTypeID           = 6
+	ErrorCodeMalformedCommand               = 7
+	ErrorCodeNotSupported                   = 8
+	ErrorCodeUnknownHost                    = 9
+	ErrorCodeResourceTemporarilyUnavailable = 10
+	ErrorCodeGenericError                   = 11
 )

--- a/aeron/image.go
+++ b/aeron/image.go
@@ -68,6 +68,7 @@ func (image *Image) IsClosed() bool {
 	return image.isClosed.Get()
 }
 
+//go:norace
 func (image *Image) Poll(handler term.FragmentHandler, fragmentLimit int) int {
 	if image.IsClosed() {
 		return 0

--- a/aeron/logbuffer/header.go
+++ b/aeron/logbuffer/header.go
@@ -30,6 +30,7 @@ type Header struct {
 	positionBitsToShift int32
 }
 
+//go:norace
 func (hdr *Header) Wrap(ptr unsafe.Pointer, length int32) *Header {
 	hdr.buffer.Wrap(ptr, length)
 	return hdr

--- a/aeron/position.go
+++ b/aeron/position.go
@@ -41,11 +41,13 @@ func NewPosition(buffer *atomic.Buffer, id int32) Position {
 	return pos
 }
 
+//go:norace
 func (pos *Position) get() int64 {
 	p := pos.buffer.GetInt64(pos.offset)
 	return p
 }
 
+//go:norace
 func (pos *Position) set(value int64) {
 	pos.buffer.PutInt64(pos.offset, value)
 }

--- a/aeron/subscription.go
+++ b/aeron/subscription.go
@@ -185,6 +185,7 @@ func (sub *Subscription) ControlledPoll(handler term.ControlledFragmentHandler, 
 	return fragmentsRead
 }
 
+//go:norace
 func (sub *Subscription) hasImage(sessionID int32) bool {
 	img := sub.images.Get()
 	for _, image := range img {
@@ -195,6 +196,7 @@ func (sub *Subscription) hasImage(sessionID int32) bool {
 	return false
 }
 
+//go:norace
 func (sub *Subscription) addImage(image *Image) *[]Image {
 
 	images := sub.images.Get()
@@ -204,6 +206,7 @@ func (sub *Subscription) addImage(image *Image) *[]Image {
 	return &images
 }
 
+//go:norace
 func (sub *Subscription) removeImage(correlationID int64) *Image {
 
 	img := sub.images.Get()

--- a/aeron/util/bits.go
+++ b/aeron/util/bits.go
@@ -77,6 +77,7 @@ func IsPowerOfTwo(value int64) bool {
 }
 
 // Memcpy will copy length bytes from pointer src to dest
+//go:nocheckptr
 func Memcpy(dest uintptr, src uintptr, length int32) {
 	var i int32
 

--- a/archive/examples/basic_recording_publisher/basic_recording_publisher.go
+++ b/archive/examples/basic_recording_publisher/basic_recording_publisher.go
@@ -62,7 +62,7 @@ func main() {
 	}
 	defer arch.Close()
 
-	channel := *examples.Config.SampleChannel + "|ssc=true"
+	channel := *examples.Config.MdcChannel + "|ssc=true"
 	stream := int32(*examples.Config.SampleStream)
 
 	if _, err := arch.StartRecording(channel, stream, true, true); err != nil {

--- a/archive/examples/basic_replay_merge/basic_replay_merge.go
+++ b/archive/examples/basic_replay_merge/basic_replay_merge.go
@@ -37,7 +37,7 @@ var logger = logging.MustGetLogger(logID)
 func main() {
 	flag.Parse()
 
-	sampleChannel := *examples.Config.SampleChannel
+	sampleChannel := *examples.Config.MdcChannel
 	sampleStream := int32(*examples.Config.SampleStream)
 	responseStream := sampleStream + 2
 
@@ -145,6 +145,8 @@ func main() {
 		arch.RecordingEventsPoll()
 		idleStrategy.Idle(fragmentsRead)
 	}
+
+	merge.Close()
 
 	for {
 		fragmentsRead := subscription.Poll(printHandler, 10)

--- a/archive/examples/examplesconfig.go
+++ b/archive/examples/examplesconfig.go
@@ -28,6 +28,7 @@ var Config = struct {
 	ResponseChannel *string
 	SampleStream    *int
 	SampleChannel   *string
+	MdcChannel      *string
 	AeronPrefix     *string
 	ProfilerEnabled *bool
 	DriverTimeout   *int64
@@ -38,9 +39,10 @@ var Config = struct {
 	flag.Int("requeststream", 10, "default request control stream to use"),
 	flag.String("requestchannel", "aeron:udp?endpoint=localhost:8010", "default request control channel to publish to"),
 	flag.Int("responsestream", 21, "default response control stream to use"),
-	flag.String("responsechannel", "aeron:udp?endpoint=localhost:8020", "default response control channel to publish to"),
+	flag.String("responsechannel", "aeron:udp?endpoint=localhost:0", "default response control channel to publish to"),
 	flag.Int("samplestream", 1001, "default response control stream to use"),
 	flag.String("samplechannel", "aeron:udp?endpoint=localhost:20121", "default response control channel to publish to"),
+	flag.String("mdcchannel", "aeron:udp?control=localhost:20121", "default response control channel to publish to"),
 	flag.String("prefix", aeron.DefaultAeronDir+"/aeron-"+aeron.UserName, "root directory for aeron driver file"),
 	flag.Bool("profile", false, "enable CPU profiling"),
 	flag.Int64("timeout", 10000, "driver liveliness timeout in ms"),

--- a/archive/options.go
+++ b/archive/options.go
@@ -50,7 +50,7 @@ type Options struct {
 var defaultOptions = Options{
 	RequestChannel:         "aeron:udp?endpoint=localhost:8010",
 	RequestStream:          10,
-	ResponseChannel:        "aeron:udp?endpoint=localhost:8020",
+	ResponseChannel:        "aeron:udp?endpoint=localhost:0",
 	ResponseStream:         20,
 	RecordingEventsChannel: "aeron:udp?control-mode=dynamic|control=localhost:8030",
 	RecordingEventsStream:  30,

--- a/archive/replaymerge/replaymerge.go
+++ b/archive/replaymerge/replaymerge.go
@@ -88,10 +88,10 @@ func NewReplayMerge(
 	recordingId int64,
 	startPosition int64,
 	mergeProgressTimeoutMs int64) (rm *ReplayMerge, err error) {
-	if strings.HasPrefix(subscription.Channel(), aeron.IpcMedia) ||
-		strings.HasPrefix(replayChannel, aeron.IpcMedia) ||
-		strings.HasPrefix(replayDestination, aeron.IpcMedia) ||
-		strings.HasPrefix(liveDestination, aeron.IpcMedia) {
+	if strings.HasPrefix(subscription.Channel(), aeron.IpcChannel) ||
+		strings.HasPrefix(replayChannel, aeron.IpcChannel) ||
+		strings.HasPrefix(replayDestination, aeron.IpcChannel) ||
+		strings.HasPrefix(liveDestination, aeron.IpcChannel) {
 		err = fmt.Errorf("IPC merging is not supported")
 		return
 	}

--- a/archive/replaymerge/replaymerge.go
+++ b/archive/replaymerge/replaymerge.go
@@ -290,10 +290,10 @@ func (rm *ReplayMerge) getRecordingPosition(nowMs int64) (workCount int, err err
 		return
 	}
 	if success {
-		nextTargetPosition := rm.polledRelevantId()
+		rm.nextTargetPosition = rm.polledRelevantId()
 		rm.activeCorrelationId = aeron.NullValue
 
-		if archive.RecordingPositionNull == nextTargetPosition {
+		if archive.RecordingPositionNull == rm.nextTargetPosition {
 			correlationId := rm.archive.Aeron().NextCorrelationID()
 
 			if rm.archive.Proxy.StopPositionRequest(correlationId, rm.recordingId) == nil {


### PR DESCRIPTION
* Fix archive to use wildcard port responses and bug in replay merge
* In PollForDescriptors, don't return as soon as no fragments were read in the current poll. There could still be responses incoming.