### PR TITLE
Closer parity to C++ and Java implementation

### DIFF
--- a/archive/replaymerge/replaymerge.go
+++ b/archive/replaymerge/replaymerge.go
@@ -180,6 +180,7 @@ func (rm *ReplayMerge) DoWork() (workCount int, err error) {
 			return
 		}
 		if err = rm.checkProgress(nowMs); err != nil {
+			rm.setState(StateFailed)
 			return
 		}
 	case StateGetRecordingPosition:
@@ -189,6 +190,7 @@ func (rm *ReplayMerge) DoWork() (workCount int, err error) {
 			return
 		}
 		if err = rm.checkProgress(nowMs); err != nil {
+			rm.setState(StateFailed)
 			return
 		}
 	case StateReplay:
@@ -198,6 +200,7 @@ func (rm *ReplayMerge) DoWork() (workCount int, err error) {
 			return
 		}
 		if err = rm.checkProgress(nowMs); err != nil {
+			rm.setState(StateFailed)
 			return
 		}
 	case StateCatchup:
@@ -207,6 +210,7 @@ func (rm *ReplayMerge) DoWork() (workCount int, err error) {
 			return
 		}
 		if err = rm.checkProgress(nowMs); err != nil {
+			rm.setState(StateFailed)
 			return
 		}
 	case StateAttemptLiveJoin:
@@ -216,6 +220,7 @@ func (rm *ReplayMerge) DoWork() (workCount int, err error) {
 			return
 		}
 		if err = rm.checkProgress(nowMs); err != nil {
+			rm.setState(StateFailed)
 			return
 		}
 	}


### PR DESCRIPTION
Using the [C++ source](https://github.com/real-logic/aeron/blob/master/aeron-archive/src/main/cpp/client/ReplayMerge.h) as a model, `checkProgress` throws, and any throwable in `doWork` is caught, state set to fail, and re thrown.

This appears to also be the behavior of the Java client.

Currently, if the state machine falls into a timeout scenario and the image continues to make no progress (due to an aws ingress issue for example), then the state machine will spin in the last state it was in. This makes it difficult for the caller to "give up" and move on to reading a live subscription because ReplayMerge will not fall into a failure state.