### PR TITLE
Add ability to override global logging config

### DIFF
--- a/aeron/logging/logging_test.go
+++ b/aeron/logging/logging_test.go
@@ -1,8 +1,9 @@
 package logging
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -32,5 +33,4 @@ func TestLogLevels(t *testing.T) {
 	logger.Warning("Log at Warning")
 	logger.Info("Log at Info")
 	logger.Debug("Log at Debug") // Silent
-
 }


### PR DESCRIPTION
Simplest way I could think of to override default config, rebuild any existing package loggers and make sure future package logger instantiations apply new config. I currently don't see a way to override the package loggers, which is problematic for log ingestion for us because our log pipeline expects json, not structured console logging. Make debugging a pain.

This should be 100% backwards compatible. If not, please let me know.

Another approach would be to add a logging initialization step to the `logging` package which allowed the caller to explicitly bootstrap all package loggers with a config, and change the behavior of `MustGetLogger` such that it first checks whether the logger exists in `namedLoggers`, if so return it otherwise lazily build it like it does today.