### PR TITLE
fix infinite loop

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -255,7 +255,7 @@ func (cc *ClientConductor) forceCloseResources() {
 				}
 			}
 		default:
-			break
+			return
 		}
 	}
 }

--- a/examples/cluster/echo_service.go
+++ b/examples/cluster/echo_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lirm/aeron-go/aeron/atomic"
 	"github.com/lirm/aeron-go/aeron/idlestrategy"
 	"github.com/lirm/aeron-go/aeron/logbuffer"
+	"github.com/lirm/aeron-go/aeron/logging"
 	"github.com/lirm/aeron-go/cluster"
 	"github.com/lirm/aeron-go/cluster/codecs"
 )
@@ -131,6 +132,8 @@ func main() {
 		opts.ClusterDir = "/tmp/aeron-go-poc/cluster"
 	}
 
+	opts.Loglevel = logging.DEBUG
+	opts.ArchiveOptions.AeronLoglevel = logging.DEBUG
 	service := &EchoService{}
 	agent, err := cluster.NewClusteredServiceAgent(ctx, opts, service)
 	if err != nil {

--- a/examples/cluster/echo_service.go
+++ b/examples/cluster/echo_service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lirm/aeron-go/aeron/atomic"
 	"github.com/lirm/aeron-go/aeron/idlestrategy"
 	"github.com/lirm/aeron-go/aeron/logbuffer"
-	"github.com/lirm/aeron-go/aeron/logging"
 	"github.com/lirm/aeron-go/cluster"
 	"github.com/lirm/aeron-go/cluster/codecs"
 )
@@ -132,8 +131,6 @@ func main() {
 		opts.ClusterDir = "/tmp/aeron-go-poc/cluster"
 	}
 
-	opts.Loglevel = logging.DEBUG
-	opts.ArchiveOptions.AeronLoglevel = logging.DEBUG
 	service := &EchoService{}
 	agent, err := cluster.NewClusteredServiceAgent(ctx, opts, service)
 	if err != nil {


### PR DESCRIPTION
Previously, the code will only break out from the switch but does not break out for the infinite for loop. 
We need to return instead so the go routine can exit, otherwise it loops forever. 