### PR TITLE
Subscriber error handling

### DIFF
--- a/aeron/aeron.go
+++ b/aeron/aeron.go
@@ -89,6 +89,7 @@ func Connect(ctx *Context) (*Aeron, error) {
 	aeron.conductor.onNewSubscriptionHandler = ctx.newSubscriptionHandler
 
 	aeron.conductor.errorHandler = ctx.errorHandler
+	aeron.conductor.subscriberErrorHandler = ctx.GetSubscriberErrorHandler()
 
 	aeron.conductor.Start(ctx.idleStrategy)
 

--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -131,6 +131,7 @@ type ClientConductor struct {
 	onAvailableImageHandler   AvailableImageHandler
 	onUnavailableImageHandler UnavailableImageHandler
 	errorHandler              func(error)
+	subscriberErrorHandler    func(error)
 
 	running          atomic.Bool
 	conductorRunning atomic.Bool
@@ -651,7 +652,7 @@ func (cc *ClientConductor) OnAvailableImage(streamID int32, sessionID int32, log
 				image.subscriptionRegistrationID = sub.regID
 				image.sourceIdentity = sourceIdentity
 				image.subscriberPosition = NewPosition(cc.counterValuesBuffer, subscriberPositionID)
-				image.exceptionHandler = cc.errorHandler
+				image.errorHandler = cc.subscriberErrorHandler
 				logger.Debugf("OnAvailableImage: new image position: %v -> %d",
 					image.subscriberPosition, image.subscriberPosition.get())
 

--- a/aeron/fragmentassembler.go
+++ b/aeron/fragmentassembler.go
@@ -67,7 +67,7 @@ func (f *FragmentAssembler) OnFragment(
 	buffer *atomic.Buffer,
 	offset int32,
 	length int32,
-	header *logbuffer.Header) {
+	header *logbuffer.Header) error {
 	flags := header.Flags()
 	if (flags & unfragmented) == unfragmented {
 		f.delegate(buffer, offset, length, header)
@@ -96,4 +96,5 @@ func (f *FragmentAssembler) OnFragment(
 			}
 		}
 	}
+	return nil
 }

--- a/aeron/image.go
+++ b/aeron/image.go
@@ -26,7 +26,7 @@ import (
 type Image struct {
 	sourceIdentity     string
 	logBuffers         *logbuffer.LogBuffers
-	exceptionHandler   func(error)
+	errorHandler       func(error)
 	termBuffers        [logbuffer.PartitionCount]*atomic.Buffer
 	subscriberPosition Position
 	header             logbuffer.Header
@@ -79,7 +79,7 @@ func (image *Image) Poll(handler term.FragmentHandler, fragmentLimit int) int {
 	index := indexByPosition(position, image.positionBitsToShift)
 	termBuffer := image.termBuffers[index]
 
-	offset, result := term.Read(termBuffer, termOffset, handler, fragmentLimit, &image.header)
+	offset, result := term.Read(termBuffer, termOffset, handler, fragmentLimit, &image.header, image.errorHandler)
 
 	newPosition := position + int64(offset-termOffset)
 	if newPosition > position {

--- a/aeron/logbuffer/term/fragmenthandler.go
+++ b/aeron/logbuffer/term/fragmenthandler.go
@@ -20,4 +20,4 @@ import (
 )
 
 // FragmentHandler is the main callback interface for received data
-type FragmentHandler func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header)
+type FragmentHandler func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error

--- a/aeron/subscription_test.go
+++ b/aeron/subscription_test.go
@@ -32,7 +32,8 @@ const (
 	SessionId       = int32(0x5E55101D)
 )
 
-func fakeFragmentHandler(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+func fakeFragmentHandler(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
+	return nil
 }
 
 // If Image is non-nil, caller has to tear down the internal fake logbuffer by calling

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -310,8 +310,9 @@ func NewArchive(options *Options, context *aeron.Context) (*Archive, error) {
 
 	for archive.Control.State.state != ControlStateConnected && archive.Control.State.err == nil {
 		fragments := archive.Control.poll(
-			func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+			func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 				ConnectionControlFragmentHandler(&pollContext, buf, offset, length, header)
+				return nil
 			}, 1)
 		if fragments > 0 {
 			logger.Debugf("Read %d fragment(s)", fragments)

--- a/archive/examples/basic_replay_merge/basic_replay_merge.go
+++ b/archive/examples/basic_replay_merge/basic_replay_merge.go
@@ -96,10 +96,11 @@ func main() {
 	defer subscription.Close()
 
 	counter := 0
-	printHandler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	printHandler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		bytes := buffer.GetBytesArray(offset, length)
 		logger.Infof("Message: %s", bytes)
 		counter++
+		return nil
 	}
 
 	idleStrategy := idlestrategy.Sleeping{SleepFor: time.Millisecond * 100}

--- a/archive/examples/basic_replayed_subscriber/basic_replayed_subscriber.go
+++ b/archive/examples/basic_replayed_subscriber/basic_replayed_subscriber.go
@@ -96,10 +96,11 @@ func main() {
 	logger.Infof("Subscription found %v", subscription)
 
 	counter := 0
-	printHandler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	printHandler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		bytes := buffer.GetBytesArray(offset, length)
 		logger.Infof("%s", bytes)
 		counter++
+		return nil
 	}
 
 	idleStrategy := idlestrategy.Sleeping{SleepFor: time.Millisecond * 1000}

--- a/archive/recordingevents.go
+++ b/archive/recordingevents.go
@@ -49,8 +49,9 @@ func (rea *RecordingEventsAdapter) PollWithContext(handler FragmentHandlerWithLi
 		fragmentLimit = 1
 	}
 	return rea.Subscription.Poll(
-		func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+		func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 			handler(rea.archive.Listeners, buf, offset, length, header)
+			return nil
 		}, fragmentLimit)
 }
 

--- a/cluster/bounded_log_adapter.go
+++ b/cluster/bounded_log_adapter.go
@@ -39,7 +39,7 @@ func (adapter *boundedLogAdapter) onFragment(
 	offset int32,
 	length int32,
 	header *logbuffer.Header,
-) {
+) error {
 	flags := header.Flags()
 	if (flags & unfragmented) == unfragmented {
 		adapter.onMessage(buffer, offset, length, header)
@@ -61,6 +61,7 @@ func (adapter *boundedLogAdapter) onFragment(
 			adapter.builder.Reset()
 		}
 	}
+	return nil
 }
 
 func (adapter *boundedLogAdapter) onMessage(

--- a/cluster/client/aeron_cluster.go
+++ b/cluster/client/aeron_cluster.go
@@ -342,9 +342,9 @@ func (ac *AeronCluster) pollEgress(fragmentLimit int) int {
 	return ac.egressSub.Poll(ac.fragmentAssembler.OnFragment, fragmentLimit)
 }
 
-func (ac *AeronCluster) onFragment(buffer *atomic.Buffer, offset, length int32, header *logbuffer.Header) {
+func (ac *AeronCluster) onFragment(buffer *atomic.Buffer, offset, length int32, header *logbuffer.Header) error {
 	if length < cluster.SBEHeaderLength {
-		return
+		return nil
 	}
 	blockLength := buffer.GetUInt16(offset)
 	templateId := buffer.GetUInt16(offset + 2)
@@ -353,7 +353,8 @@ func (ac *AeronCluster) onFragment(buffer *atomic.Buffer, offset, length int32, 
 	if schemaId != cluster.ClusterSchemaId {
 		logger.Errorf("unexpected schemaId=%d templateId=%d blockLen=%d version=%d",
 			schemaId, templateId, blockLength, version)
-		return
+		// TODO: Should return an error
+		return nil
 	}
 	offset += cluster.SBEHeaderLength
 	length -= cluster.SBEHeaderLength
@@ -375,6 +376,7 @@ func (ac *AeronCluster) onFragment(buffer *atomic.Buffer, offset, length int32, 
 			logger.Warningf("received challenge, corrId=%d clusterSessionId=%d", e.CorrelationId, e.ClusterSessionId)
 		}
 	}
+	return nil
 }
 
 func (ac *AeronCluster) onNewLeaderEvent(buffer *atomic.Buffer, offset, length int32, version, blockLength uint16) {

--- a/cluster/service_adapter.go
+++ b/cluster/service_adapter.go
@@ -27,9 +27,9 @@ func (adapter *serviceAdapter) onFragment(
 	offset int32,
 	length int32,
 	header *logbuffer.Header,
-) {
+) error {
 	if length < SBEHeaderLength {
-		return
+		return nil
 	}
 	blockLength := buffer.GetUInt16(offset)
 	templateId := buffer.GetUInt16(offset + 2)
@@ -38,7 +38,8 @@ func (adapter *serviceAdapter) onFragment(
 	if schemaId != ClusterSchemaId {
 		logger.Errorf("serviceAdapter: unexpected schemaId=%d templateId=%d blockLen=%d version=%d",
 			schemaId, templateId, blockLength, version)
-		return
+		// TODO: Convert to returned error, as is done in the Java ServiceAdapter
+		return nil
 	}
 	offset += SBEHeaderLength
 	length -= SBEHeaderLength
@@ -68,4 +69,5 @@ func (adapter *serviceAdapter) onFragment(
 	default:
 		logger.Debugf("serviceAdapter: unexpected templateId=%d at pos=%d", templateId, header.Position())
 	}
+	return nil
 }

--- a/cluster/snapshot_loader.go
+++ b/cluster/snapshot_loader.go
@@ -37,9 +37,9 @@ func (loader *snapshotLoader) onFragment(
 	offset int32,
 	length int32,
 	header *logbuffer.Header,
-) {
+) error {
 	if length < SBEHeaderLength {
-		return
+		return nil
 	}
 	blockLength := buffer.GetUInt16(offset)
 	templateId := buffer.GetUInt16(offset + 2)
@@ -48,7 +48,8 @@ func (loader *snapshotLoader) onFragment(
 	if schemaId != ClusterSchemaId {
 		logger.Errorf("SnapshotLoader: unexpected schemaId=%d templateId=%d blockLen=%d version=%d",
 			schemaId, templateId, blockLength, version)
-		return
+		// TODO: Convert to returned error, as is done in the Java ServiceSnapshotLoader
+		return nil
 	}
 	offset += SBEHeaderLength
 	length -= SBEHeaderLength
@@ -97,4 +98,5 @@ func (loader *snapshotLoader) onFragment(
 	default:
 		logger.Debugf("SnapshotLoader: unknown templateId=%d at pos=%d", templateId, header.Position())
 	}
+	return nil
 }

--- a/examples/basic_rpc/client/basic_client.go
+++ b/examples/basic_rpc/client/basic_client.go
@@ -121,13 +121,14 @@ func main() {
 
 	tmpBuf := &bytes.Buffer{}
 	counter := 1
-	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		bytes := buffer.GetBytesArray(offset, length)
 		tmpBuf.Reset()
 		buffer.WriteBytes(tmpBuf, offset, length)
 		fmt.Printf("%8.d: Gots me a fragment offset:%d length: %d payload: %s (buf:%s)\n", counter, offset, length, string(bytes), string(tmpBuf.Next(int(length))))
 
 		counter++
+		return nil
 	}
 
 	idleStrategy := idlestrategy.Sleeping{SleepFor: time.Millisecond}

--- a/examples/basic_rpc/server/basic_server.go
+++ b/examples/basic_rpc/server/basic_server.go
@@ -78,7 +78,7 @@ func main() {
 		}
 	}()
 
-	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		bytes := buffer.GetBytesArray(offset, length)
 
 		c, found := clients[header.SessionId()]
@@ -88,6 +88,7 @@ func main() {
 			}
 			clients[header.SessionId()] = c
 		}
+		return nil
 	}
 
 	idleStrategy := idlestrategy.Sleeping{SleepFor: time.Millisecond}

--- a/examples/basic_subscriber/basic_subscriber.go
+++ b/examples/basic_subscriber/basic_subscriber.go
@@ -60,13 +60,14 @@ func main() {
 
 	tmpBuf := &bytes.Buffer{}
 	counter := 1
-	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		bytes := buffer.GetBytesArray(offset, length)
 		tmpBuf.Reset()
 		buffer.WriteBytes(tmpBuf, offset, length)
 		fmt.Printf("%8.d: Gots me a fragment offset:%d length: %d payload: %s (buf:%s)\n", counter, offset, length, string(bytes), string(tmpBuf.Next(int(length))))
 
 		counter++
+		return nil
 	}
 
 	idleStrategy := idlestrategy.Sleeping{SleepFor: time.Millisecond}

--- a/examples/cluster/echo_service.go
+++ b/examples/cluster/echo_service.go
@@ -22,13 +22,15 @@ func (s *EchoService) OnStart(cluster cluster.Cluster, image *aeron.Image) {
 	if image == nil {
 		fmt.Printf("OnStart with no image\n")
 	} else {
-		cnt := image.Poll(func(buf *atomic.Buffer, offset int32, length int32, hdr *logbuffer.Header) {
+		cnt := image.Poll(func(buf *atomic.Buffer, offset int32, length int32, hdr *logbuffer.Header) error {
 			if length == 4 && s.messageCount == 0 {
 				s.messageCount = buf.GetInt32(offset)
 			} else {
+				// TODO: Return a proper error
 				fmt.Printf("WARNING: unexpected snapshot message - pos=%d offset=%d length=%d\n",
 					hdr.Position(), offset, length)
 			}
+			return nil
 		}, 100)
 		fmt.Printf("OnStart with image - snapshotMsgCnt=%d messageCount=%d\n", cnt, s.messageCount)
 	}

--- a/examples/ping/ping.go
+++ b/examples/ping/ping.go
@@ -85,7 +85,7 @@ func main() {
 
 	hist := hdrhistogram.New(1, 1000000000, 3)
 
-	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		sent := buffer.GetInt64(offset)
 		now := time.Now().UnixNano()
 
@@ -95,6 +95,7 @@ func main() {
 			logger.Debugf("Received message at offset %d, length %d, position %d, termId %d, frame len %d",
 				offset, length, header.Offset(), header.TermId(), header.FrameLength())
 		}
+		return nil
 	}
 
 	srcBuffer := atomic.MakeBuffer(make([]byte, *examples.ExamplesConfig.Size))

--- a/examples/pong/pong.go
+++ b/examples/pong/pong.go
@@ -93,7 +93,7 @@ func main() {
 		done <- true
 	}()
 
-	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		if logger.IsEnabledFor(logging.DEBUG) {
 			logger.Debugf("Received message at offset %d, length %d, position %d, termId %d, frame len %d",
 				offset, length, header.Offset(), header.TermId(), header.FrameLength())
@@ -106,6 +106,7 @@ func main() {
 				//	panic(fmt.Sprintf("Failed to send message of %d bytes due to %d", length, ret))
 			}
 		}
+		return nil
 	}
 
 	go func() {

--- a/systests/buffer_claim_message_test.go
+++ b/systests/buffer_claim_message_test.go
@@ -63,8 +63,9 @@ func (suite *BufferClaimMessageTestSuite) TearDownSuite() {
 
 func (suite *BufferClaimMessageTestSuite) TestShouldReceivePublishedMessageWithInterleavedAbort() {
 	fragmentCount := 0
-	fragmentHandler := func(*atomic.Buffer, int32, int32, *logbuffer.Header) {
+	fragmentHandler := func(*atomic.Buffer, int32, int32, *logbuffer.Header) error {
 		fragmentCount++
+		return nil
 	}
 
 	var bufferClaim logbuffer.Claim
@@ -119,9 +120,10 @@ func (suite *BufferClaimMessageTestSuite) TestShouldTransferReservedValue() {
 	bufferClaim.SetReservedValue(reservedValue)
 	bufferClaim.Commit()
 
-	fragmentHandler := func(_ *atomic.Buffer, _ int32, length int32, header *logbuffer.Header) {
+	fragmentHandler := func(_ *atomic.Buffer, _ int32, length int32, header *logbuffer.Header) error {
 		suite.Assert().EqualValues(messageLength, length)
 		suite.Assert().EqualValues(reservedValue, header.GetReservedValue())
+		return nil
 	}
 
 	for 1 != subscription.Poll(fragmentHandler, fragmentCountLimit) {

--- a/systests/client_error_handler_test.go
+++ b/systests/client_error_handler_test.go
@@ -1,0 +1,117 @@
+// Copyright 2022 Steven Stern
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systests
+
+import (
+	"errors"
+	"github.com/lirm/aeron-go/aeron"
+	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/logbuffer"
+	"github.com/lirm/aeron-go/systests/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+const (
+	streamId = 1001
+	channel  = "aeron:ipc"
+	sleep    = 50 * time.Millisecond
+)
+
+// Note: This is inspired by the Java test shouldHaveCorrectTermBufferLength in ClientErrorHandlerTest.  The name is a
+// copy/paste bug.
+func TestShouldUseCorrectErrorHandlers(t *testing.T) {
+	mediaDriver, err := driver.StartMediaDriver()
+	require.NoError(t, err, "Couldn't start Media Driver")
+	defer mediaDriver.StopMediaDriver()
+
+	errChanOne := make(chan error, 10)
+	clientCtxOne := aeron.NewContext().AeronDir(mediaDriver.TempDir).
+		ErrorHandler(func(err error) { errChanOne <- err })
+
+	// Note: Java uses a RethrowingErrorHandler.  There is no Go equivalent.  Instead, this tests that the correct error
+	// handler is used, which is also part of the Java test.
+	errChanTwo := make(chan error, 10)
+	clientCtxTwo := aeron.NewContext().AeronDir(mediaDriver.TempDir).
+		ErrorHandler(func(err error) { require.Fail(t, "Wrong error handler called") }).
+		SubscriberErrorHandler(func(err error) { errChanTwo <- err })
+
+	aeronOne, err := aeron.Connect(clientCtxOne)
+	require.NoError(t, err, "Couldn't connect to Media Driver")
+	defer aeronOne.Close()
+
+	aeronTwo, err := aeron.Connect(clientCtxTwo)
+	require.NoError(t, err, "Couldn't connect to Media Driver")
+	defer aeronTwo.Close()
+
+	publication := <-aeronTwo.AddPublication(channel, streamId)
+	require.NotNil(t, publication, "Couldn't AddPublication")
+	defer publication.Close()
+
+	subscriptionOne := <-aeronOne.AddSubscription(channel, streamId)
+	require.NotNil(t, subscriptionOne, "Couldn't AddSubscription")
+	defer subscriptionOne.Close()
+
+	subscriptionTwo := <-aeronTwo.AddSubscription(channel, streamId)
+	require.NotNil(t, subscriptionTwo, "Couldn't AddSubscription")
+	defer subscriptionTwo.Close()
+
+	for !subscriptionOne.IsConnected() {
+		time.Sleep(sleep)
+	}
+	for !subscriptionTwo.IsConnected() {
+		time.Sleep(sleep)
+	}
+
+	buffer := atomic.MakeBuffer(make([]byte, 100), 100)
+	for publication.Offer(buffer, 0, 100, nil) < 0 {
+		time.Sleep(sleep)
+	}
+
+	expectedError := errors.New("expected")
+	handler := func(_ *atomic.Buffer, _ int32, _ int32, _ *logbuffer.Header) error {
+		return expectedError
+	}
+
+	for subscriptionOne.Poll(handler, 1) == 0 {
+		time.Sleep(sleep)
+	}
+	select {
+	case err := <-errChanOne:
+		assert.Equal(t, expectedError, err)
+	default:
+		assert.Fail(t, "Error not propagated")
+	}
+
+	for subscriptionTwo.Poll(handler, 1) == 0 {
+		time.Sleep(sleep)
+	}
+	select {
+	case err := <-errChanTwo:
+		assert.Equal(t, expectedError, err)
+	default:
+		assert.Fail(t, "Error not propagated")
+	}
+
+	select {
+	case err := <-errChanOne:
+		assert.Failf(t, "Too many errors handled: %s", err.Error())
+	case err := <-errChanTwo:
+		assert.Failf(t, "Too many errors handled: %s", err.Error())
+	default:
+	}
+}

--- a/systests/client_error_handler_test.go
+++ b/systests/client_error_handler_test.go
@@ -27,14 +27,14 @@ import (
 )
 
 const (
-	streamId = 1001
-	channel  = "aeron:ipc"
-	sleep    = 50 * time.Millisecond
+	channel = "aeron:ipc"
+	sleep   = 50 * time.Millisecond
 )
 
 // Note: This is inspired by the Java test shouldHaveCorrectTermBufferLength in ClientErrorHandlerTest.  The name is a
 // copy/paste bug.
 func TestShouldUseCorrectErrorHandlers(t *testing.T) {
+	const streamId = 1001
 	mediaDriver, err := driver.StartMediaDriver()
 	require.NoError(t, err, "Couldn't start Media Driver")
 	defer mediaDriver.StopMediaDriver()

--- a/systests/sys_test.go
+++ b/systests/sys_test.go
@@ -77,9 +77,10 @@ func send(n int, pub *aeron.Publication) {
 
 func receive(n int, sub *aeron.Subscription) {
 	counter := 0
-	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+	handler := func(buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) error {
 		logger.Debugf("    message: %s", string(buffer.GetBytesArray(offset, length)))
 		counter++
+		return nil
 	}
 	var fragmentsRead atomic.Int
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
Changed FragmentHandler so it returns an error.  That error gets propagated up through Image.poll(), and will interrupt a batch poll. This is the functionality in Java Aeron.

Added an optional subscriber-specific error handler, mirroring the Java impl.

Note that this is fully functional, but I wouldn't call it done.  There are a few existing places where a logged error should be converted to a returned error.  I should also make the equivalent change in the ControlledFragmentHandler.  However, I wanted to get initial feedback on this approach, especially considering that it breaks a public API (although in a tiny way - adding "return nil" fixes the break)