### PR TITLE
In ClientConductor, call forceCloseResources before setting conductorRunning to false

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -310,9 +310,8 @@ func (cc *ClientConductor) run(idleStrategy idlestrategy.Idler) {
 			cc.onError(errors.New(errStr))
 			cc.running.Set(false)
 		}
-		cc.conductorRunning.Set(false)
-
 		cc.forceCloseResources()
+		cc.conductorRunning.Set(false)
 
 		logger.Infof("ClientConductor done")
 	}()


### PR DESCRIPTION
[ClientConductor.Close](https://github.com/talostrading/aeron-go/blob/4404b837d191ffd460346bfa493a849311c0cf1b/aeron/clientconductor.go#L194-L196) waits for conductorRunning to be set to false before continuing, so if it is allowed to continue before forceCloseResources, the parent Aeron instance and its underlying counters memory buffer could get garbage collected before forceCloseResources is run. forceCloseResources could then try to access the now missing, underlying counters memory buffer while cleaning up lingering resources and run into an seg fault.