### PR TITLE
Enable Offer To Cluster

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -8,37 +8,37 @@ import (
 
 type Cluster interface {
 
-	// LogPosition returns the position the log has reached in bytes as of the current message.
+	// LogPosition returns the position the log has reached in bytes as of the current message
 	LogPosition() int64
 
-	// MemberId returns the unique id for the hosting member of the cluster. Useful only for debugging purposes.
+	// MemberId returns the unique id for the hosting member of the cluster. Useful only for debugging purposes
 	MemberId() int32
 
-	// Role returns the role the cluster node is playing.
+	// Role returns the role the cluster node is playing
 	Role() Role
 
-	// Time returns the cluster time as time units since 1 Jan 1970 UTC.
+	// Time returns the cluster time as time units since 1 Jan 1970 UTC
 	Time() int64
 
-	// TimeUnit returns the unit of time applied when timestamping and time operations.
+	// TimeUnit returns the unit of time applied when timestamping and time operations
 	TimeUnit() codecs.ClusterTimeUnitEnum
 
 	// IdleStrategy returns the IdleStrategy which should be used by the service when it experiences back-pressure on egress,
-	// closing sessions, making timer requests, or any long-running actions.
+	// closing sessions, making timer requests, or any long-running actions
 	IdleStrategy() idlestrategy.Idler
 
 	// ScheduleTimer schedules a timer for a given deadline and provide a correlation id to identify the timer when it expires or
 	// for cancellation. This action is asynchronous and will race with the timer expiring.
 	//
 	// If the correlationId is for an existing scheduled timer then it will be rescheduled to the new deadline. However,
-	// it is best to generate correl~~ationIds in a monotonic fashion and be aware of potential clashes with other
+	// it is best to generate correllationIds in a monotonic fashion and be aware of potential clashes with other
 	// services in the same cluster. Service isolation can be achieved by using the upper bits for service id.
 	//
-	// Timers should only be scheduled or cancelled in the context of processing a
-	// ClusteredService#onSessionMessage(ClientSession, int64, DirectBuffer, int, int, Header)
-	// ClusteredService#onTimerEvent(int64, int64)
-	// ClusteredService#onSessionOpen(ClientSession, int64) or
-	// ClusteredService#onSessionClose(ClientSession, int64, CloseReason)
+	// Timers should only be scheduled or cancelled in the context of processing
+	// - onSessionMessage
+	// - onTimerEvent
+	// - onSessionOpen
+	// - onSessionClose
 	// If applied to other events then they are not guaranteed to be reliable.
 	//
 	// Callers of this method should loop until the method succeeds.
@@ -46,38 +46,29 @@ type Cluster interface {
 	// The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
 	// shutdown if required.
 	//
-	// correlationId to identify the timer when it expires.
-	// deadline      time after which the timer will fire.
-	// ScheduleTimer returns true if the event to schedule a timer request has been sent or false if back-pressure is applied.
+	// ScheduleTimer returns true if the event to schedule a timer request has been sent or false if back-pressure is applied
 	ScheduleTimer(correlationId int64, deadline int64) bool
 
 	// CancelTimer cancels a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
 	//
-	// Timers should only be scheduled or cancelled in the context of processing a
-	// ClusteredService#onSessionMessage(ClientSession, int64, DirectBuffer, int, int, Header)
-	// ClusteredService#onTimerEvent(int64, int64)
-	// ClusteredService#onSessionOpen(ClientSession, int64) or
-	// ClusteredService#onSessionClose(ClientSession, int64, CloseReason)
+	// Timers should only be scheduled or cancelled in the context of processing
+	// - onSessionMessage
+	// - onTimerEvent
+	// - onSessionOpen
+	// - onSessionClose
 	// If applied to other events then they are not guaranteed to be reliable.
 	//
-	// Callers of this method should loop until the method succeeds, see
-	// Cluster#scheduleTimer(int64, int64) for an example.
+	// Callers of this method should loop until the method succeeds.
 	//
-	// correlationId for the timer provided when it was scheduled. Long#MAX_VALUE not supported.
 	// CancelTimer   returns true if the event to cancel request has been sent or false if back-pressure is applied.
 	CancelTimer(correlationId int64) bool
 
 	// Offer a message as ingress to the cluster for sequencing. This will happen efficiently over IPC to the
-	// consensus module and set the cluster session as the negative value of the cluster.Options#ServiceID
+	// consensus module and set the cluster session as the negative value of the cluster's ServiceID
 	//
 	// Callers of this method should loop until the method succeeds.
 	//
 	// The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
-	// shutdown if required.
-	//
-	// buffer containing the message to be offered.
-	// offset in the buffer at which the encoded message begins.
-	// length in the buffer of the encoded message.
-	// Offer  returns positive value if successful.
+	// shutdown if required
 	Offer(*atomic.Buffer, int32, int32) int64
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -8,7 +8,7 @@ import (
 
 type Cluster interface {
 
-	// Position returns the position the log has reached in bytes as of the current message.
+	// LogPosition returns the position the log has reached in bytes as of the current message.
 	LogPosition() int64
 
 	// MemberId returns the unique id for the hosting member of the cluster. Useful only for debugging purposes.
@@ -27,7 +27,7 @@ type Cluster interface {
 	// closing sessions, making timer requests, or any long-running actions.
 	IdleStrategy() idlestrategy.Idler
 
-	// Schedule a timer for a given deadline and provide a correlation id to identify the timer when it expires or
+	// ScheduleTimer schedules a timer for a given deadline and provide a correlation id to identify the timer when it expires or
 	// for cancellation. This action is asynchronous and will race with the timer expiring.
 	//
 	// If the correlationId is for an existing scheduled timer then it will be rescheduled to the new deadline. However,
@@ -51,7 +51,7 @@ type Cluster interface {
 	// ScheduleTimer returns true if the event to schedule a timer request has been sent or false if back-pressure is applied.
 	ScheduleTimer(correlationId int64, deadline int64) bool
 
-	// Cancel a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
+	// CancelTimer cancels a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
 	//
 	// Timers should only be scheduled or cancelled in the context of processing a
 	// ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -7,143 +7,78 @@ import (
 )
 
 type Cluster interface {
-	/**
-	 * Position the log has reached in bytes as of the current message.
-	 *
-	 * @return position the log has reached in bytes as of the current message.
-	 */
+
+	// Position returns the position the log has reached in bytes as of the current message.
 	LogPosition() int64
 
-	/**
-	 * The unique id for the hosting member of the cluster. Useful only for debugging purposes.
-	 *
-	 * @return unique id for the hosting member of the cluster.
-	 */
+	// MemberId returns the unique id for the hosting member of the cluster. Useful only for debugging purposes.
 	MemberId() int32
 
-	/**
-	 * The role the cluster node is playing.
-	 *
-	 * @return the role the cluster node is playing.
-	 */
+	// Role returns the role the cluster node is playing.
 	Role() Role
 
-	/**
-	 * Cluster time as {@link #timeUnit()}s since 1 Jan 1970 UTC.
-	 *
-	 * @return time as {@link #timeUnit()}s since 1 Jan 1970 UTC.
-	 */
+	// Time returns the cluster time as time units since 1 Jan 1970 UTC.
 	Time() int64
 
-	/**
-	 * The unit of time applied when timestamping and {@link #time()} operations.
-	 *
-	 * @return the unit of time applied when timestamping and {@link #time()} operations.
-	 */
+	// TimeUnit returns the unit of time applied when timestamping and time operations.
 	TimeUnit() codecs.ClusterTimeUnitEnum
 
-	/**
-	 * {@link IdleStrategy} which should be used by the service when it experiences back-pressure on egress,
-	 * closing sessions, making timer requests, or any long-running actions.
-	 *
-	 * @return the {@link IdleStrategy} which should be used by the service when it experiences back-pressure.
-	 */
+	// IdleStrategy returns the IdleStrategy which should be used by the service when it experiences back-pressure on egress,
+	// closing sessions, making timer requests, or any long-running actions.
 	IdleStrategy() idlestrategy.Idler
 
-	/**
-	 * Schedule a timer for a given deadline and provide a correlation id to identify the timer when it expires or
-	 * for cancellation. This action is asynchronous and will race with the timer expiring.
-	 * <p>
-	 * If the correlationId is for an existing scheduled timer then it will be rescheduled to the new deadline. However,
-	 * it is best to generate correl~~ationIds in a monotonic fashion and be aware of potential clashes with other
-	 * services in the same cluster. Service isolation can be achieved by using the upper bits for service id.
-	 * <p>
-	 * Timers should only be scheduled or cancelled in the context of processing a
-	 * {@link ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)},
-	 * {@link ClusteredService#onTimerEvent(long, long)},
-	 * {@link ClusteredService#onSessionOpen(ClientSession, long)}, or
-	 * {@link ClusteredService#onSessionClose(ClientSession, long, CloseReason)}.
-	 * If applied to other events then they are not guaranteed to be reliable.
-	 * <p>
-	 * Callers of this method should loop until the method succeeds.
-	 *
-	 * <pre>{@code
-	 * private Cluster cluster;
-	 * // Lines omitted...
-	 *
-	 * cluster.idleStrategy().reset();
-	 * while (!cluster.scheduleTimer(correlationId, deadline))
-	 * {
-	 *     cluster.idleStrategy().idle();
-	 * }
-	 * }</pre>
-	 *
-	 * The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
-	 * shutdown if required.
-	 *
-	 * @param correlationId to identify the timer when it expires. {@link Long#MAX_VALUE} not supported.
-	 * @param deadline      time after which the timer will fire. {@link Long#MAX_VALUE} not supported.
-	 * @return true if the event to schedule a timer request has been sent or false if back-pressure is applied.
-	 * @see #cancelTimer(long)
-	 */
+	// Schedule a timer for a given deadline and provide a correlation id to identify the timer when it expires or
+	// for cancellation. This action is asynchronous and will race with the timer expiring.
+	//
+	// If the correlationId is for an existing scheduled timer then it will be rescheduled to the new deadline. However,
+	// it is best to generate correl~~ationIds in a monotonic fashion and be aware of potential clashes with other
+	// services in the same cluster. Service isolation can be achieved by using the upper bits for service id.
+	//
+	// Timers should only be scheduled or cancelled in the context of processing a
+	// ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)
+	// ClusteredService#onTimerEvent(long, long)
+	// ClusteredService#onSessionOpen(ClientSession, long) or
+	// ClusteredService#onSessionClose(ClientSession, long, CloseReason)
+	// If applied to other events then they are not guaranteed to be reliable.
+	//
+	// Callers of this method should loop until the method succeeds.
+	//
+	// The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
+	// shutdown if required.
+	//
+	// correlationId to identify the timer when it expires.
+	// deadline      time after which the timer will fire.
+	// ScheduleTimer returns true if the event to schedule a timer request has been sent or false if back-pressure is applied.
 	ScheduleTimer(correlationId int64, deadline int64) bool
 
-	/**
-	 * Cancel a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
-	 * <p>
-	 * Timers should only be scheduled or cancelled in the context of processing a
-	 * {@link ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)},
-	 * {@link ClusteredService#onTimerEvent(long, long)},
-	 * {@link ClusteredService#onSessionOpen(ClientSession, long)}, or
-	 * {@link ClusteredService#onSessionClose(ClientSession, long, CloseReason)}.
-	 * If applied to other events then they are not guaranteed to be reliable.
-	 * <p>
-	 * Callers of this method should loop until the method succeeds, see {@link
-	 * io.aeron.cluster.service.Cluster#scheduleTimer(long, long)} for an example.
-	 *
-	 * @param correlationId for the timer provided when it was scheduled. {@link Long#MAX_VALUE} not supported.
-	 * @return true if the event to cancel request has been sent or false if back-pressure is applied.
-	 * @see #scheduleTimer(long, long)
-	 */
+	// Cancel a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
+	//
+	// Timers should only be scheduled or cancelled in the context of processing a
+	// ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)
+	// ClusteredService#onTimerEvent(long, long)
+	// ClusteredService#onSessionOpen(ClientSession, long) or
+	// ClusteredService#onSessionClose(ClientSession, long, CloseReason)
+	// If applied to other events then they are not guaranteed to be reliable.
+	//
+	// Callers of this method should loop until the method succeeds, see {@link
+	// io.aeron.cluster.service.Cluster#scheduleTimer(long, long)} for an example.
+	//
+	// correlationId for the timer provided when it was scheduled. Long#MAX_VALUE not supported.
+	// CancelTimer   returns true if the event to cancel request has been sent or false if back-pressure is applied.
 	CancelTimer(correlationId int64) bool
 
-	/**
-	 * Offer a message as ingress to the cluster for sequencing. This will happen efficiently over IPC to the
-	 * consensus module and have the cluster session of as the negative value of the
-	 * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME}.
-	 * <p>
-	 * Callers of this method should loop until the method succeeds.
-	 *
-	 * <pre>{@code
-	 * private Cluster cluster;
-	 * // Lines omitted...
-	 *
-	 * cluster.idleStrategy().reset();
-	 * do
-	 * {
-	 *     final long position = cluster.offer(buffer, offset, length);
-	 *     if (position > 0)
-	 *     {
-	 *         break;
-	 *     }
-	 *     else if (Publication.ADMIN_ACTION != position || Publication.BACK_PRESSURED != position)
-	 *     {
-	 *         throw new ClusterException("Internal offer failed: " + position);
-	 *     }
-	 *
-	 *     cluster.idleStrategy.idle();
-	 * }
-	 * while (true);
-	 * }</pre>
-	 *
-	 * The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
-	 * shutdown if required.
-	 *
-	 * @param buffer containing the message to be offered.
-	 * @param offset in the buffer at which the encoded message begins.
-	 * @param length in the buffer of the encoded message.
-	 * @return positive value if successful.
-	 * @see io.aeron.Publication#offer(DirectBuffer, int, int)
-	 */
+	// Offer a message as ingress to the cluster for sequencing. This will happen efficiently over IPC to the
+	// consensus module and have the cluster session of as the negative value of the
+	// io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME
+	//
+	// Callers of this method should loop until the method succeeds.
+	//
+	// The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
+	// shutdown if required.
+	//
+	// buffer containing the message to be offered.
+	// offset in the buffer at which the encoded message begins.
+	// length in the buffer of the encoded message.
+	// Offer  returns positive value if successful.
 	Offer(*atomic.Buffer, int32, int32) int64
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -35,10 +35,10 @@ type Cluster interface {
 	// services in the same cluster. Service isolation can be achieved by using the upper bits for service id.
 	//
 	// Timers should only be scheduled or cancelled in the context of processing a
-	// ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)
-	// ClusteredService#onTimerEvent(long, long)
-	// ClusteredService#onSessionOpen(ClientSession, long) or
-	// ClusteredService#onSessionClose(ClientSession, long, CloseReason)
+	// ClusteredService#onSessionMessage(ClientSession, int64, DirectBuffer, int, int, Header)
+	// ClusteredService#onTimerEvent(int64, int64)
+	// ClusteredService#onSessionOpen(ClientSession, int64) or
+	// ClusteredService#onSessionClose(ClientSession, int64, CloseReason)
 	// If applied to other events then they are not guaranteed to be reliable.
 	//
 	// Callers of this method should loop until the method succeeds.
@@ -54,22 +54,21 @@ type Cluster interface {
 	// CancelTimer cancels a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
 	//
 	// Timers should only be scheduled or cancelled in the context of processing a
-	// ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)
-	// ClusteredService#onTimerEvent(long, long)
-	// ClusteredService#onSessionOpen(ClientSession, long) or
-	// ClusteredService#onSessionClose(ClientSession, long, CloseReason)
+	// ClusteredService#onSessionMessage(ClientSession, int64, DirectBuffer, int, int, Header)
+	// ClusteredService#onTimerEvent(int64, int64)
+	// ClusteredService#onSessionOpen(ClientSession, int64) or
+	// ClusteredService#onSessionClose(ClientSession, int64, CloseReason)
 	// If applied to other events then they are not guaranteed to be reliable.
 	//
-	// Callers of this method should loop until the method succeeds, see {@link
-	// io.aeron.cluster.service.Cluster#scheduleTimer(long, long)} for an example.
+	// Callers of this method should loop until the method succeeds, see
+	// Cluster#scheduleTimer(int64, int64) for an example.
 	//
 	// correlationId for the timer provided when it was scheduled. Long#MAX_VALUE not supported.
 	// CancelTimer   returns true if the event to cancel request has been sent or false if back-pressure is applied.
 	CancelTimer(correlationId int64) bool
 
 	// Offer a message as ingress to the cluster for sequencing. This will happen efficiently over IPC to the
-	// consensus module and have the cluster session of as the negative value of the
-	// io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME
+	// consensus module and set the cluster session as the negative value of the cluster.Options#ServiceID
 	//
 	// Callers of this method should loop until the method succeeds.
 	//

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,15 +1,149 @@
 package cluster
 
-import "github.com/lirm/aeron-go/aeron/idlestrategy"
+import (
+	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/idlestrategy"
+	"github.com/lirm/aeron-go/cluster/codecs"
+)
 
 type Cluster interface {
+	/**
+	 * Position the log has reached in bytes as of the current message.
+	 *
+	 * @return position the log has reached in bytes as of the current message.
+	 */
 	LogPosition() int64
+
+	/**
+	 * The unique id for the hosting member of the cluster. Useful only for debugging purposes.
+	 *
+	 * @return unique id for the hosting member of the cluster.
+	 */
 	MemberId() int32
+
+	/**
+	 * The role the cluster node is playing.
+	 *
+	 * @return the role the cluster node is playing.
+	 */
 	Role() Role
+
+	/**
+	 * Cluster time as {@link #timeUnit()}s since 1 Jan 1970 UTC.
+	 *
+	 * @return time as {@link #timeUnit()}s since 1 Jan 1970 UTC.
+	 */
 	Time() int64
+
+	/**
+	 * The unit of time applied when timestamping and {@link #time()} operations.
+	 *
+	 * @return the unit of time applied when timestamping and {@link #time()} operations.
+	 */
+	TimeUnit() codecs.ClusterTimeUnitEnum
+
+	/**
+	 * {@link IdleStrategy} which should be used by the service when it experiences back-pressure on egress,
+	 * closing sessions, making timer requests, or any long-running actions.
+	 *
+	 * @return the {@link IdleStrategy} which should be used by the service when it experiences back-pressure.
+	 */
 	IdleStrategy() idlestrategy.Idler
 
-	// ScheduleTimer schedules a timer for a given deadline
+	/**
+	 * Schedule a timer for a given deadline and provide a correlation id to identify the timer when it expires or
+	 * for cancellation. This action is asynchronous and will race with the timer expiring.
+	 * <p>
+	 * If the correlationId is for an existing scheduled timer then it will be rescheduled to the new deadline. However,
+	 * it is best to generate correl~~ationIds in a monotonic fashion and be aware of potential clashes with other
+	 * services in the same cluster. Service isolation can be achieved by using the upper bits for service id.
+	 * <p>
+	 * Timers should only be scheduled or cancelled in the context of processing a
+	 * {@link ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)},
+	 * {@link ClusteredService#onTimerEvent(long, long)},
+	 * {@link ClusteredService#onSessionOpen(ClientSession, long)}, or
+	 * {@link ClusteredService#onSessionClose(ClientSession, long, CloseReason)}.
+	 * If applied to other events then they are not guaranteed to be reliable.
+	 * <p>
+	 * Callers of this method should loop until the method succeeds.
+	 *
+	 * <pre>{@code
+	 * private Cluster cluster;
+	 * // Lines omitted...
+	 *
+	 * cluster.idleStrategy().reset();
+	 * while (!cluster.scheduleTimer(correlationId, deadline))
+	 * {
+	 *     cluster.idleStrategy().idle();
+	 * }
+	 * }</pre>
+	 *
+	 * The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
+	 * shutdown if required.
+	 *
+	 * @param correlationId to identify the timer when it expires. {@link Long#MAX_VALUE} not supported.
+	 * @param deadline      time after which the timer will fire. {@link Long#MAX_VALUE} not supported.
+	 * @return true if the event to schedule a timer request has been sent or false if back-pressure is applied.
+	 * @see #cancelTimer(long)
+	 */
 	ScheduleTimer(correlationId int64, deadline int64) bool
+
+	/**
+	 * Cancel a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
+	 * <p>
+	 * Timers should only be scheduled or cancelled in the context of processing a
+	 * {@link ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)},
+	 * {@link ClusteredService#onTimerEvent(long, long)},
+	 * {@link ClusteredService#onSessionOpen(ClientSession, long)}, or
+	 * {@link ClusteredService#onSessionClose(ClientSession, long, CloseReason)}.
+	 * If applied to other events then they are not guaranteed to be reliable.
+	 * <p>
+	 * Callers of this method should loop until the method succeeds, see {@link
+	 * io.aeron.cluster.service.Cluster#scheduleTimer(long, long)} for an example.
+	 *
+	 * @param correlationId for the timer provided when it was scheduled. {@link Long#MAX_VALUE} not supported.
+	 * @return true if the event to cancel request has been sent or false if back-pressure is applied.
+	 * @see #scheduleTimer(long, long)
+	 */
 	CancelTimer(correlationId int64) bool
+
+	/**
+	 * Offer a message as ingress to the cluster for sequencing. This will happen efficiently over IPC to the
+	 * consensus module and have the cluster session of as the negative value of the
+	 * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME}.
+	 * <p>
+	 * Callers of this method should loop until the method succeeds.
+	 *
+	 * <pre>{@code
+	 * private Cluster cluster;
+	 * // Lines omitted...
+	 *
+	 * cluster.idleStrategy().reset();
+	 * do
+	 * {
+	 *     final long position = cluster.offer(buffer, offset, length);
+	 *     if (position > 0)
+	 *     {
+	 *         break;
+	 *     }
+	 *     else if (Publication.ADMIN_ACTION != position || Publication.BACK_PRESSURED != position)
+	 *     {
+	 *         throw new ClusterException("Internal offer failed: " + position);
+	 *     }
+	 *
+	 *     cluster.idleStrategy.idle();
+	 * }
+	 * while (true);
+	 * }</pre>
+	 *
+	 * The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
+	 * shutdown if required.
+	 *
+	 * @param buffer containing the message to be offered.
+	 * @param offset in the buffer at which the encoded message begins.
+	 * @param length in the buffer of the encoded message.
+	 * @return positive value if successful.
+	 * @see io.aeron.Publication#offer(DirectBuffer, int, int)
+	 */
+	Offer(*atomic.Buffer, int32, int32) int64
 }

--- a/cluster/clustered_service.go
+++ b/cluster/clustered_service.go
@@ -8,50 +8,40 @@ import (
 )
 
 type ClusteredService interface {
-	/**
-	 * Start event for the service where the service can perform any initialisation required and load snapshot state.
-	 * The snapshot image can be null if no previous snapshot exists.
-	 * <p>
-	 * <b>Note:</b> As this is a potentially long-running operation the implementation should use
-	 * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
-	 * {@link org.agrona.concurrent.IdleStrategy#idle(int)}, especially when polling the {@link Image} returns 0.
-	 *
-	 * @param cluster       with which the service can interact.
-	 * @param snapshotImage from which the service can load its archived state which can be null when no snapshot.
-	 */
+	// StartEvent is called to initialize the service and load snapshot state, where the snapshot image can be nil if no previous snapshot exists.
+	//
+	// Note: As this can potentially be a long-running operation, the implementation should use Cluster.IdleStrategy() and
+	// occasionally call IdleStrategy.Idle() or IdleStrategy.Idle(int), especially when polling the Image returns 0.
+	//
+	// cluster the Cluster with which the service can interact.
+	// snapshotImage the Image from which the service can load its archived state, which can be nil when there is no snapshot.
 	OnStart(cluster Cluster, image aeron.Image)
 
-	/**
-	 * A session has been opened for a client to the cluster.
-	 *
-	 * @param session   for the client which have been opened.
-	 * @param timestamp at which the session was opened.
-	 */
+	// A session has been opened for a client to the cluster.
+	//
+	// session   for the client which have been opened.
+	// timestamp at which the session was opened.
 	OnSessionOpen(session ClientSession, timestamp int64)
 
-	/**
-	 * A session has been closed for a client to the cluster.
-	 *
-	 * @param session     that has been closed.
-	 * @param timestamp   at which the session was closed.
-	 * @param closeReason the session was closed.
-	 */
+	// A session has been closed for a client to the cluster.
+	//
+	// session     that has been closed.
+	// timestamp   at which the session was closed.
+	// closeReason the session was closed.
 	OnSessionClose(
 		session ClientSession,
 		timestamp int64,
 		closeReason codecs.CloseReasonEnum,
 	)
 
-	/**
-	 * A message has been received to be processed by a clustered service.
-	 *
-	 * @param session   for the client which sent the message. This can be null if the client was a service.
-	 * @param timestamp for when the message was received.
-	 * @param buffer    containing the message.
-	 * @param offset    in the buffer at which the message is encoded.
-	 * @param length    of the encoded message.
-	 * @param header    aeron header for the incoming message.
-	 */
+	// A message has been received to be processed by a clustered service.
+	//
+	// session   for the client which sent the message. This can be null if the client was a service.
+	// timestamp for when the message was received.
+	// buffer    containing the message.
+	// offset    in the buffer at which the message is encoded.
+	// length    of the encoded message.
+	// header    aeron header for the incoming message.
 	OnSessionMessage(
 		session ClientSession,
 		timestamp int64,
@@ -61,52 +51,41 @@ type ClusteredService interface {
 		header *logbuffer.Header,
 	)
 
-	/**
-	 * A scheduled timer has expired.
-	 *
-	 * @param correlationId for the expired timer.
-	 * @param timestamp     at which the timer expired.
-	 */
+	// A scheduled timer has expired.
+	//
+	// correlationId for the expired timer.
+	// timestamp     at which the timer expired.
 	OnTimerEvent(correlationId, timestamp int64)
 
-	/**
-	 * The service should take a snapshot and store its state to the provided archive {@link Publication}.
-	 * <p>
-	 * <b>Note:</b> As this is a potentially long-running operation the implementation should use
-	 * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
-	 * {@link org.agrona.concurrent.IdleStrategy#idle(int)},
-	 * especially when the snapshot {@link ExclusivePublication} returns {@link Publication#BACK_PRESSURED}.
-	 *
-	 * @param publication to which the state should be recorded.
-	 */
+	// The service should take a snapshot and store its state to the provided archive Publication.
+	//
+	// Note: As this is a potentially long-running operation the implementation should use
+	// Cluster#idleStrategy() and then occasionally call IdleStrategy#idle()
+	// especially when the snapshot ExclusivePublication returns Publication#BACK_PRESSURED.
+	//
+	// publication to which the state should be recorded.
 	OnTakeSnapshot(publication *aeron.Publication)
 
-	/**
-	 * Notify that the cluster node has changed role.
-	 *
-	 * @param role that the node has assumed.
-	 */
+	// Notify that the cluster node has changed role.
+	//
+	// role that the node has assumed.
 	OnRoleChange(role Role)
 
-	/**
-	 * Called when the container is going to terminate.
-	 *
-	 * @param cluster with which the service can interact.
-	 */
+	// Called when the container is going to terminate.
+	//
+	// cluster with which the service can interact.
 	OnTerminate(cluster Cluster)
 
-	/**
-	 * An election has been successful and a leader has entered a new term.
-	 *
-	 * @param leadershipTermId    identity for the new leadership term.
-	 * @param logPosition         position the log has reached as the result of this message.
-	 * @param timestamp           for the new leadership term.
-	 * @param termBaseLogPosition position at the beginning of the leadership term.
-	 * @param leaderMemberId      who won the election.
-	 * @param logSessionId        session id for the publication of the log.
-	 * @param timeUnit            for the timestamps in the coming leadership term.
-	 * @param appVersion          for the application configured in the consensus module.
-	 */
+	// An election has been successful and a leader has entered a new term.
+	//
+	// leadershipTermId    identity for the new leadership term.
+	// logPosition         position the log has reached as the result of this message.
+	// timestamp           for the new leadership term.
+	// termBaseLogPosition position at the beginning of the leadership term.
+	// leaderMemberId      who won the election.
+	// logSessionId        session id for the publication of the log.
+	// timeUnit            for the timestamps in the coming leadership term.
+	// appVersion          for the application configured in the consensus module.
 	OnNewLeadershipTermEvent(
 		leadershipTermId int64,
 		logPosition int64,

--- a/cluster/clustered_service.go
+++ b/cluster/clustered_service.go
@@ -11,37 +11,20 @@ type ClusteredService interface {
 	// OnStart is called to initialize the service and load snapshot state, where the snapshot image can be nil if no previous snapshot exists.
 	//
 	// Note: As this can potentially be a long-running operation, the implementation should use Cluster.IdleStrategy() and
-	// occasionally call IdleStrategy.Idle() or IdleStrategy.Idle(int), especially when polling the Image returns 0.
-	//
-	// cluster the Cluster with which the service can interact.
-	// snapshotImage the Image from which the service can load its archived state, which can be nil when there is no snapshot.
+	// occasionally call IdleStrategy.Idle() or IdleStrategy.Idle(int), especially when polling the Image returns 0
 	OnStart(cluster Cluster, image aeron.Image)
 
-	// OnSessionOpen notifies the clustered service that a session has been opened for a client to the cluster.
-	//
-	// session   for the client which have been opened.
-	// timestamp at which the session was opened.
+	// OnSessionOpen notifies the clustered service that a session has been opened for a client to the cluster
 	OnSessionOpen(session ClientSession, timestamp int64)
 
-	// OnSessionClose notifies the clustered service that a session has been closed for a client to the cluster.
-	//
-	// session     that has been closed.
-	// timestamp   at which the session was closed.
-	// closeReason the session was closed.
+	// OnSessionClose notifies the clustered service that a session has been closed for a client to the cluster
 	OnSessionClose(
 		session ClientSession,
 		timestamp int64,
 		closeReason codecs.CloseReasonEnum,
 	)
 
-	// OnSessionMessage notifies the clustered service that a message has been received to be processed by a clustered service.
-	//
-	// session   for the client which sent the message. This can be null if the client was a service.
-	// timestamp for when the message was received.
-	// buffer    containing the message.
-	// offset    in the buffer at which the message is encoded.
-	// length    of the encoded message.
-	// header    aeron header for the incoming message.
+	// OnSessionMessage notifies the clustered service that a message has been received to be processed by a clustered service
 	OnSessionMessage(
 		session ClientSession,
 		timestamp int64,
@@ -51,41 +34,23 @@ type ClusteredService interface {
 		header *logbuffer.Header,
 	)
 
-	// OnTimerEvent notifies the clustered service that a scheduled timer has expired.
-	//
-	// correlationId for the expired timer.
-	// timestamp     at which the timer expired.
+	// OnTimerEvent notifies the clustered service that a scheduled timer has expired
 	OnTimerEvent(correlationId, timestamp int64)
 
 	// OnTakeSnapshot instructs the clustered service to take a snapshot and store its state to the provided aeron archive Publication.
 	//
 	// Note: As this is a potentially long-running operation the implementation should use
 	// Cluster#idleStrategy() and then occasionally call IdleStrategy#idle()
-	// especially when the snapshot ExclusivePublication returns Publication#BACK_PRESSURED.
-	//
-	// publication to which the state should be recorded.
+	// especially when the snapshot ExclusivePublication returns Publication#BACK_PRESSURED
 	OnTakeSnapshot(publication *aeron.Publication)
 
-	// OnRoleChange notifies the clustered service that the cluster node has changed role.
-	//
-	// role that the node has assumed.
+	// OnRoleChange notifies the clustered service that the cluster node has changed role
 	OnRoleChange(role Role)
 
-	// OnTerminate notifies the clustered service that the container is going to terminate.
-	//
-	// cluster with which the service can interact.
+	// OnTerminate notifies the clustered service that the container is going to terminate
 	OnTerminate(cluster Cluster)
 
-	// OnNewLeadershipTermEvent notifies the clustered service that an election has been successful and a leader has entered a new term.
-	//
-	// leadershipTermId    identity for the new leadership term.
-	// logPosition         position the log has reached as the result of this message.
-	// timestamp           for the new leadership term.
-	// termBaseLogPosition position at the beginning of the leadership term.
-	// leaderMemberId      who won the election.
-	// logSessionId        session id for the publication of the log.
-	// timeUnit            for the timestamps in the coming leadership term.
-	// appVersion          for the application configured in the consensus module.
+	// OnNewLeadershipTermEvent notifies the clustered service that an election has been successful and a leader has entered a new term
 	OnNewLeadershipTermEvent(
 		leadershipTermId int64,
 		logPosition int64,

--- a/cluster/clustered_service.go
+++ b/cluster/clustered_service.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ClusteredService interface {
-	// StartEvent is called to initialize the service and load snapshot state, where the snapshot image can be nil if no previous snapshot exists.
+	// OnStart is called to initialize the service and load snapshot state, where the snapshot image can be nil if no previous snapshot exists.
 	//
 	// Note: As this can potentially be a long-running operation, the implementation should use Cluster.IdleStrategy() and
 	// occasionally call IdleStrategy.Idle() or IdleStrategy.Idle(int), especially when polling the Image returns 0.
@@ -17,13 +17,13 @@ type ClusteredService interface {
 	// snapshotImage the Image from which the service can load its archived state, which can be nil when there is no snapshot.
 	OnStart(cluster Cluster, image aeron.Image)
 
-	// A session has been opened for a client to the cluster.
+	// OnSessionOpen notifies the clustered service that a session has been opened for a client to the cluster.
 	//
 	// session   for the client which have been opened.
 	// timestamp at which the session was opened.
 	OnSessionOpen(session ClientSession, timestamp int64)
 
-	// A session has been closed for a client to the cluster.
+	// OnSessionClose notifies the clustered service that a session has been closed for a client to the cluster.
 	//
 	// session     that has been closed.
 	// timestamp   at which the session was closed.
@@ -34,7 +34,7 @@ type ClusteredService interface {
 		closeReason codecs.CloseReasonEnum,
 	)
 
-	// A message has been received to be processed by a clustered service.
+	// OnSessionMessage notifies the clustered service that a message has been received to be processed by a clustered service.
 	//
 	// session   for the client which sent the message. This can be null if the client was a service.
 	// timestamp for when the message was received.
@@ -51,13 +51,13 @@ type ClusteredService interface {
 		header *logbuffer.Header,
 	)
 
-	// A scheduled timer has expired.
+	// OnTimerEvent notifies the clustered service that a scheduled timer has expired.
 	//
 	// correlationId for the expired timer.
 	// timestamp     at which the timer expired.
 	OnTimerEvent(correlationId, timestamp int64)
 
-	// The service should take a snapshot and store its state to the provided archive Publication.
+	// OnTakeSnapshot instructs the clustered service to take a snapshot and store its state to the provided aeron archive Publication.
 	//
 	// Note: As this is a potentially long-running operation the implementation should use
 	// Cluster#idleStrategy() and then occasionally call IdleStrategy#idle()
@@ -66,17 +66,17 @@ type ClusteredService interface {
 	// publication to which the state should be recorded.
 	OnTakeSnapshot(publication *aeron.Publication)
 
-	// Notify that the cluster node has changed role.
+	// OnRoleChange notifies the clustered service that the cluster node has changed role.
 	//
 	// role that the node has assumed.
 	OnRoleChange(role Role)
 
-	// Called when the container is going to terminate.
+	// OnTerminate notifies the clustered service that the container is going to terminate.
 	//
 	// cluster with which the service can interact.
 	OnTerminate(cluster Cluster)
 
-	// An election has been successful and a leader has entered a new term.
+	// OnNewLeadershipTermEvent notifies the clustered service that an election has been successful and a leader has entered a new term.
 	//
 	// leadershipTermId    identity for the new leadership term.
 	// logPosition         position the log has reached as the result of this message.

--- a/cluster/clustered_service.go
+++ b/cluster/clustered_service.go
@@ -11,7 +11,7 @@ type ClusteredService interface {
 	// OnStart is called to initialize the service and load snapshot state, where the snapshot image can be nil if no previous snapshot exists.
 	//
 	// Note: As this can potentially be a long-running operation, the implementation should use Cluster.IdleStrategy() and
-	// occasionally call IdleStrategy.Idle() or IdleStrategy.Idle(int), especially when polling the Image returns 0
+	// occasionally call IdleStrategy.Idle(), especially when polling the Image returns 0
 	OnStart(cluster Cluster, image aeron.Image)
 
 	// OnSessionOpen notifies the clustered service that a session has been opened for a client to the cluster
@@ -40,8 +40,8 @@ type ClusteredService interface {
 	// OnTakeSnapshot instructs the clustered service to take a snapshot and store its state to the provided aeron archive Publication.
 	//
 	// Note: As this is a potentially long-running operation the implementation should use
-	// Cluster#idleStrategy() and then occasionally call IdleStrategy#idle()
-	// especially when the snapshot ExclusivePublication returns Publication#BACK_PRESSURED
+	// Cluster.idleStrategy() and then occasionally call IdleStrategy.idle()
+	// especially when the snapshot ExclusivePublication returns Publication.BACK_PRESSURED
 	OnTakeSnapshot(publication *aeron.Publication)
 
 	// OnRoleChange notifies the clustered service that the cluster node has changed role

--- a/cluster/clustered_service.go
+++ b/cluster/clustered_service.go
@@ -8,16 +8,50 @@ import (
 )
 
 type ClusteredService interface {
+	/**
+	 * Start event for the service where the service can perform any initialisation required and load snapshot state.
+	 * The snapshot image can be null if no previous snapshot exists.
+	 * <p>
+	 * <b>Note:</b> As this is a potentially long-running operation the implementation should use
+	 * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
+	 * {@link org.agrona.concurrent.IdleStrategy#idle(int)}, especially when polling the {@link Image} returns 0.
+	 *
+	 * @param cluster       with which the service can interact.
+	 * @param snapshotImage from which the service can load its archived state which can be null when no snapshot.
+	 */
 	OnStart(cluster Cluster, image aeron.Image)
 
+	/**
+	 * A session has been opened for a client to the cluster.
+	 *
+	 * @param session   for the client which have been opened.
+	 * @param timestamp at which the session was opened.
+	 */
 	OnSessionOpen(session ClientSession, timestamp int64)
 
+	/**
+	 * A session has been closed for a client to the cluster.
+	 *
+	 * @param session     that has been closed.
+	 * @param timestamp   at which the session was closed.
+	 * @param closeReason the session was closed.
+	 */
 	OnSessionClose(
 		session ClientSession,
 		timestamp int64,
 		closeReason codecs.CloseReasonEnum,
 	)
 
+	/**
+	 * A message has been received to be processed by a clustered service.
+	 *
+	 * @param session   for the client which sent the message. This can be null if the client was a service.
+	 * @param timestamp for when the message was received.
+	 * @param buffer    containing the message.
+	 * @param offset    in the buffer at which the message is encoded.
+	 * @param length    of the encoded message.
+	 * @param header    aeron header for the incoming message.
+	 */
 	OnSessionMessage(
 		session ClientSession,
 		timestamp int64,
@@ -27,14 +61,52 @@ type ClusteredService interface {
 		header *logbuffer.Header,
 	)
 
+	/**
+	 * A scheduled timer has expired.
+	 *
+	 * @param correlationId for the expired timer.
+	 * @param timestamp     at which the timer expired.
+	 */
 	OnTimerEvent(correlationId, timestamp int64)
 
+	/**
+	 * The service should take a snapshot and store its state to the provided archive {@link Publication}.
+	 * <p>
+	 * <b>Note:</b> As this is a potentially long-running operation the implementation should use
+	 * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
+	 * {@link org.agrona.concurrent.IdleStrategy#idle(int)},
+	 * especially when the snapshot {@link ExclusivePublication} returns {@link Publication#BACK_PRESSURED}.
+	 *
+	 * @param publication to which the state should be recorded.
+	 */
 	OnTakeSnapshot(publication *aeron.Publication)
 
+	/**
+	 * Notify that the cluster node has changed role.
+	 *
+	 * @param role that the node has assumed.
+	 */
 	OnRoleChange(role Role)
 
+	/**
+	 * Called when the container is going to terminate.
+	 *
+	 * @param cluster with which the service can interact.
+	 */
 	OnTerminate(cluster Cluster)
 
+	/**
+	 * An election has been successful and a leader has entered a new term.
+	 *
+	 * @param leadershipTermId    identity for the new leadership term.
+	 * @param logPosition         position the log has reached as the result of this message.
+	 * @param timestamp           for the new leadership term.
+	 * @param termBaseLogPosition position at the beginning of the leadership term.
+	 * @param leaderMemberId      who won the election.
+	 * @param logSessionId        session id for the publication of the log.
+	 * @param timeUnit            for the timestamps in the coming leadership term.
+	 * @param appVersion          for the application configured in the consensus module.
+	 */
 	OnNewLeadershipTermEvent(
 		leadershipTermId int64,
 		logPosition int64,

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -726,6 +726,10 @@ func (agent *ClusteredServiceAgent) Time() int64 {
 	return agent.clusterTime
 }
 
+func (agent *ClusteredServiceAgent) TimeUnit() codecs.ClusterTimeUnitEnum {
+	return agent.timeUnit
+}
+
 func (agent *ClusteredServiceAgent) IdleStrategy() idlestrategy.Idler {
 	return agent
 }
@@ -736,6 +740,10 @@ func (agent *ClusteredServiceAgent) ScheduleTimer(correlationId int64, deadline 
 
 func (agent *ClusteredServiceAgent) CancelTimer(correlationId int64) bool {
 	return agent.proxy.cancelTimer(correlationId)
+}
+
+func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length int32) int64 {
+	return agent.proxy.Offer(buffer, offset, length)
 }
 
 // END CLUSTER IMPLEMENTATION

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -743,7 +743,14 @@ func (agent *ClusteredServiceAgent) CancelTimer(correlationId int64) bool {
 }
 
 func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length int32) int64 {
-	return agent.proxy.Offer(buffer, offset, length)
+	if agent.role != Leader {
+		return ClientSessionMockedOffer
+	}
+
+	hdrBuf := agent.sessionMsgHdrBuffer
+	hdrBuf.PutInt64(SBEHeaderLength+8, -int64(agent.opts.ServiceId))
+	hdrBuf.PutInt64(SBEHeaderLength+16, agent.clusterTime)
+	return agent.proxy.Offer2(hdrBuf, 0, hdrBuf.Capacity(), buffer, offset, length)
 }
 
 // END CLUSTER IMPLEMENTATION


### PR DESCRIPTION
Improve documentation of cluster interfaces, and allow `ClusteredServiceAgent` to offer messages to the cluster itself. 

Comments are copied from Java implementation.

Offer capability modeled after Java Implementation:
- https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/Cluster.java#L304
- https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L329
- https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/ConsensusModuleProxy.java#L117