### PR TITLE
[RFC] Multi Service Cluster

### DIFF
--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -14,6 +14,7 @@ package cluster
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -114,7 +115,7 @@ func NewClusteredServiceAgent(
 		counterFile.MetaDataBuf.Get(),
 	)
 
-	cmf, err := NewClusterMarkFile(options.ClusterDir + "/cluster-mark-service-0.dat")
+	cmf, err := NewClusterMarkFile(options.ClusterDir + "/cluster-mark-service-" + strconv.Itoa(int(options.ServiceId)) + ".dat")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Looking to make launching multiple service containers within the same cluster possible. 

While the current golang codebase has many references to multi-service support, it does not seem to support multiple services. 

The way that service mark files are created seems to be incorrect. I dug into the Java code and found that the mark file naming deviated from the Java implementation. 

https://github.com/real-logic/aeron/blob/fb8eae58b79cb5922b3522085a6a60dea50ece92/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java#L414

However, even after applying the change, I was still unable to get multiple service containers to work. 

Wondering if anyone in the community knows how to make multiple service containers work.

### Findings
My current debugging set-up simply spins up 2 echo services. One with `serviceID = 0` and another with `serviceID = 1`. 

- Cluster elections only succeed if I first spin up `serviceID = 0` services across all nodes, wait for the election to complete, then spin up `serviceID = 1` services.
  - `serviceID = 1` services will still fail to launch. 
  - The [onStart](https://github.com/gravity-technologies/aeron-go/blob/multi-service-cluster/cluster/clustered_service_agent.go#L167) hook [succeeds in finding the position counter](https://github.com/gravity-technologies/aeron-go/blob/multi-service-cluster/cluster/clustered_service_agent.go#L181) but [fails in finding the recovery counter](https://github.com/gravity-technologies/aeron-go/blob/multi-service-cluster/cluster/clustered_service_agent.go#L191)
- If `serviceID = 0` services and `serviceID = 1` services are spun up at the same time, race condition will dominate. The first service in each node will successfully launch, and the rest will fail to launch. 
  - If a mixture of 0/1 services are launched, elections will fail.
  - Elections only succeed if all three services have the same ID.