### PR TITLE
Use ControlledPoll for PollForResponse and PollForErrorResponse

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
 	"github.com/lirm/aeron-go/aeron/logbuffer"
+	"github.com/lirm/aeron-go/aeron/logbuffer/term"
 	"github.com/lirm/aeron-go/aeron/logging"
 	"github.com/lirm/aeron-go/archive/codecs"
 )
@@ -318,8 +319,9 @@ func NewArchive(options *Options, context *aeron.Context) (*Archive, error) {
 
 	for archive.Control.State.state != ControlStateConnected && archive.Control.State.err == nil {
 		fragments := archive.Control.poll(
-			func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+			func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) term.ControlledPollAction {
 				ConnectionControlFragmentHandler(&pollContext, buf, offset, length, header)
+				return term.ControlledPollActionContinue
 			}, 1)
 		if fragments > 0 {
 			logger.Debugf("Read %d fragment(s)", fragments)

--- a/archive/control.go
+++ b/archive/control.go
@@ -113,11 +113,17 @@ func init() {
 	codecIds.recordingStopped = recordingStopped.SbeTemplateId()
 }
 
-func controlFragmentHandler(context interface{}, buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+func controlFragmentHandler(context interface{}, buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) (action term.ControlledPollAction) {
+	action = term.ControlledPollActionContinue
+
 	pollContext, ok := context.(*PollContext)
 	if !ok {
 		logger.Errorf("context conversion failed")
 		return
+	}
+
+	if pollContext.control.Results.IsPollComplete {
+		return term.ControlledPollActionAbort
 	}
 
 	logger.Debugf("controlFragmentHandler: correlationID:%d offset:%d length:%d header:%#v", pollContext.correlationID, offset, length, header)
@@ -170,6 +176,8 @@ func controlFragmentHandler(context interface{}, buffer *atomic.Buffer, offset i
 			logger.Debugf("controlFragmentHandler/controlResponse: received for sessionID:%d, correlationID:%d", controlResponse.ControlSessionId, controlResponse.CorrelationId)
 			control.Results.ControlResponse = controlResponse
 			control.Results.IsPollComplete = true
+
+			return term.ControlledPollActionBreak
 		} else {
 			logger.Debugf("controlFragmentHandler/controlResponse ignoring sessionID:%d, correlationID:%d", controlResponse.ControlSessionId, controlResponse.CorrelationId)
 		}
@@ -198,6 +206,7 @@ func controlFragmentHandler(context interface{}, buffer *atomic.Buffer, offset i
 		// This can happen when testing/adding new functionality
 		fmt.Printf("controlFragmentHandler: Unexpected message type %d\n", hdr.TemplateId)
 	}
+	return
 }
 
 // ConnectionControlFragmentHandler is the connection handling specific fragment handler.
@@ -355,9 +364,8 @@ func (control *Control) PollForErrorResponse() (int, error) {
 	for {
 		ret := control.poll(
 			func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) term.ControlledPollAction {
-				errorResponseFragmentHandler(&context, buf, offset, length, header)
-				return term.ControlledPollActionContinue
-			}, 1)
+				return errorResponseFragmentHandler(&context, buf, offset, length, header)
+			}, 10)
 		received += ret
 
 		// If we received a response with an error then return it
@@ -380,11 +388,17 @@ func (control *Control) PollForErrorResponse() (int, error) {
 //	ignore messages not on our session ID
 //	process recordingSignalEvents
 //	Log a warning if we have interrupted a synchronous event
-func errorResponseFragmentHandler(context interface{}, buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) {
+func errorResponseFragmentHandler(context interface{}, buffer *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) (action term.ControlledPollAction) {
+	action = term.ControlledPollActionContinue
+
 	pollContext, ok := context.(*PollContext)
 	if !ok {
 		logger.Errorf("context conversion failed")
 		return
+	}
+
+	if pollContext.control.Results.ErrorResponse != nil {
+		return term.ControlledPollActionAbort
 	}
 
 	logger.Debugf("errorResponseFragmentHandler: offset:%d length: %d", offset, length)
@@ -422,6 +436,7 @@ func errorResponseFragmentHandler(context interface{}, buffer *atomic.Buffer, of
 		if controlResponse.ControlSessionId == pollContext.control.archive.SessionID {
 			if controlResponse.Code == codecs.ControlResponseCode.ERROR {
 				pollContext.control.Results.ErrorResponse = fmt.Errorf("PollForErrorResponse received a ControlResponse (correlationId:%d Code:ERROR error=\"%s\"", controlResponse.CorrelationId, controlResponse.ErrorMessage)
+				return term.ControlledPollActionBreak
 			}
 		}
 		return
@@ -503,6 +518,8 @@ func errorResponseFragmentHandler(context interface{}, buffer *atomic.Buffer, of
 	default:
 		fmt.Printf("errorResponseFragmentHandler: Insert decoder for type: %d", hdr.TemplateId)
 	}
+
+	return
 }
 
 // poll provides the control response poller using local state to pass
@@ -609,11 +626,10 @@ func (control *Control) PollForResponse(correlationID int64, sessionID int64) (i
 	context := PollContext{control, correlationID}
 
 	handler := aeron.NewControlledFragmentAssembler(func(buf *atomic.Buffer, offset int32, length int32, header *logbuffer.Header) term.ControlledPollAction {
-		controlFragmentHandler(&context, buf, offset, length, header)
-		return term.ControlledPollActionContinue
+		return controlFragmentHandler(&context, buf, offset, length, header)
 	}, aeron.DefaultFragmentAssemblyBufferLength)
 	for {
-		ret := control.poll(handler.OnFragment, 1)
+		ret := control.poll(handler.OnFragment, 10)
 
 		// Check result
 		if control.Results.IsPollComplete {

--- a/archive/control.go
+++ b/archive/control.go
@@ -611,7 +611,7 @@ func (control *Control) PollForResponse(correlationID int64, sessionID int64) (i
 		controlFragmentHandler(&context, buf, offset, length, header)
 	}, aeron.DefaultFragmentAssemblyBufferLength)
 	for {
-		ret := control.poll(handler.OnFragment, 10)
+		ret := control.poll(handler.OnFragment, 1)
 
 		// Check result
 		if control.Results.IsPollComplete {

--- a/archive/control.go
+++ b/archive/control.go
@@ -349,6 +349,8 @@ func (control *Control) PollForErrorResponse() (int, error) {
 	context := PollContext{control, 0}
 	received := 0
 
+	control.Results.ErrorResponse = nil
+
 	// Poll for async events, errors etc until the queue is drained
 	for {
 		ret := control.poll(

--- a/archive/control_test.go
+++ b/archive/control_test.go
@@ -127,7 +127,6 @@ func TestControl_PollForErrorResponse(t *testing.T) {
 		cnt, err := control.PollForErrorResponse()
 		assert.EqualValues(t, 1, cnt)
 		assert.Error(t, err)
-		control.Results.ErrorResponse = nil // TODO: Should this really be necessary?
 		cnt, err = control.PollForErrorResponse()
 		assert.EqualValues(t, 1, cnt)
 		assert.NoError(t, err)

--- a/archive/control_test.go
+++ b/archive/control_test.go
@@ -62,7 +62,7 @@ func TestControl_PollForResponse(t *testing.T) {
 		assert.EqualError(t, err, `Control Response failure: b0rk`)
 	})
 
-	t.Run("discards messages after error", func(t *testing.T) { // TODO: Why?
+	t.Run("does not process messages after result", func(t *testing.T) {
 		control, image := newTestControl(t)
 		mockPollResponses(t, image,
 			&codecs.ControlResponse{
@@ -78,7 +78,7 @@ func TestControl_PollForResponse(t *testing.T) {
 		assert.EqualValues(t, 3, id)
 		assert.EqualError(t, err, `Control Response failure: b0rk`)
 		fragments := image.Poll(func(buffer *atomic.Buffer, offset, length int32, header *logbuffer.Header) {}, 1)
-		assert.Zero(t, fragments)
+		assert.EqualValues(t, 1, fragments)
 	})
 }
 

--- a/archive/control_test.go
+++ b/archive/control_test.go
@@ -1,0 +1,213 @@
+package archive
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/lirm/aeron-go/aeron"
+	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/idlestrategy"
+	"github.com/lirm/aeron-go/aeron/logbuffer"
+	"github.com/lirm/aeron-go/aeron/logbuffer/term"
+	"github.com/lirm/aeron-go/archive/codecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestControl_PollForResponse(t *testing.T) {
+	t.Run("times out when nothing to poll", func(t *testing.T) {
+		control, image := newTestControl(t)
+		image.On("Poll", mock.Anything, mock.Anything).Return(0)
+		correlations.Store(int64(1), control)
+		id, err := control.PollForResponse(1, 0)
+		assert.Zero(t, id)
+        assert.EqualError(t, err, `timeout waiting for correlationID 1`)
+	})
+
+	t.Run("returns the error response", func(t *testing.T) {
+		control, image := newTestControl(t)
+		mockPollResponses(t, image,
+			&codecs.ControlResponse{
+				Code:             codecs.ControlResponseCode.ERROR,
+				CorrelationId:    1,
+				ErrorMessage:     []byte(`b0rk`),
+				RelevantId:       3,
+			},
+		)
+		correlations.Store(int64(1), control)
+		id, err := control.PollForResponse(1, 0)
+		assert.EqualValues(t, 3, id)
+		assert.EqualError(t, err, `Control Response failure: b0rk`)
+	})
+
+	t.Run("discards all responses preceding the first error", func(t *testing.T) {
+		control, image := newTestControl(t)
+		mockPollResponses(t, image,
+			&codecs.ControlResponse{Code: codecs.ControlResponseCode.OK},
+			&codecs.ControlResponse{Code: codecs.ControlResponseCode.OK},
+			&codecs.ControlResponse{
+				Code:             codecs.ControlResponseCode.ERROR,
+				CorrelationId:    1,
+				ErrorMessage:     []byte(`b0rk`),
+				RelevantId:       3,
+			},
+		)
+		correlations.Store(int64(1), control)
+		id, err := control.PollForResponse(1, 0)
+		assert.EqualValues(t, 3, id)
+		assert.EqualError(t, err, `Control Response failure: b0rk`)
+	})
+
+	t.Run("discards messages after error", func(t *testing.T) { // TODO: Why?
+		control, image := newTestControl(t)
+		mockPollResponses(t, image,
+			&codecs.ControlResponse{
+				Code:             codecs.ControlResponseCode.ERROR,
+				CorrelationId:    1,
+				ErrorMessage:     []byte(`b0rk`),
+				RelevantId:       3,
+			},
+			&codecs.ControlResponse{Code: codecs.ControlResponseCode.OK},
+		)
+		correlations.Store(int64(1), control)
+		id, err := control.PollForResponse(1, 0)
+		assert.EqualValues(t, 3, id)
+		assert.EqualError(t, err, `Control Response failure: b0rk`)
+		fragments := image.Poll(func(buffer *atomic.Buffer, offset, length int32, header *logbuffer.Header) {}, 1)
+		assert.Zero(t, fragments)
+	})
+}
+
+func TestControl_PollForErrorResponse(t *testing.T) {
+	t.Run("returns zero when nothing to poll", func(t *testing.T) {
+		control, image := newTestControl(t)
+		image.On("Poll", mock.Anything, mock.Anything).Return(0)
+		cnt, err := control.PollForErrorResponse()
+		assert.Zero(t, cnt)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns the error response", func(t *testing.T) {
+		control, image := newTestControl(t)
+		mockPollResponses(t, image,
+			&codecs.ControlResponse{
+				Code:         codecs.ControlResponseCode.ERROR,
+				ErrorMessage: []byte(`b0rk`),
+			},
+		)
+		cnt, err := control.PollForErrorResponse()
+		assert.EqualValues(t, 1, cnt)
+		assert.EqualError(t, err, `PollForErrorResponse received a ControlResponse (correlationId:0 Code:ERROR error="b0rk"`)
+	})
+
+	t.Run("discards all queued responses unless error", func(t *testing.T) {
+		control, image := newTestControl(t)
+		mockPollResponses(t, image,
+			&codecs.ControlResponse{Code: codecs.ControlResponseCode.OK},
+			&codecs.ControlResponse{Code: codecs.ControlResponseCode.OK},
+		)
+		cnt, err := control.PollForErrorResponse()
+		assert.EqualValues(t, 2, cnt)
+		assert.NoError(t, err)
+	})
+
+	t.Run("does not process messages after error", func(t *testing.T) {
+		control, image := newTestControl(t)
+		mockPollResponses(t, image,
+			&codecs.ControlResponse{
+				Code:         codecs.ControlResponseCode.ERROR,
+				ErrorMessage: []byte(`b0rk`),
+			},
+			&codecs.ControlResponse{Code: codecs.ControlResponseCode.OK},
+		)
+		cnt, err := control.PollForErrorResponse()
+		assert.EqualValues(t, 1, cnt)
+		assert.Error(t, err)
+		control.Results.ErrorResponse = nil // TODO: Should this really be necessary?
+		cnt, err = control.PollForErrorResponse()
+		assert.EqualValues(t, 1, cnt)
+		assert.NoError(t, err)
+	})
+}
+
+func mockPollResponses(t *testing.T, image *aeron.MockImage, responses ...encodable) {
+	poll := image.On("Poll", mock.Anything, mock.Anything)
+	poll.Run(func(args mock.Arguments) {
+		fragmentCount := args.Get(1).(int)
+		count := 0
+		for ; count < fragmentCount; count++ {
+			if len(responses) == 0 {
+				break
+			}
+			buffer := encode(t, responses[0])
+			responses = responses[1:]
+			args.Get(0).(term.FragmentHandler)(buffer, 0, buffer.Capacity(), newTestHeader())
+		}
+		poll.Return(count)
+	})
+}
+
+type encodable interface {
+	SbeBlockLength() uint16
+	SbeTemplateId() uint16
+	SbeSchemaId() uint16
+	SbeSchemaVersion() uint16
+	Encode(*codecs.SbeGoMarshaller, io.Writer, bool) error
+}
+
+func encode(t *testing.T, data encodable) *atomic.Buffer {
+	m := codecs.NewSbeGoMarshaller()
+	buf := new(bytes.Buffer)
+	header := codecs.MessageHeader{
+		BlockLength: data.SbeBlockLength(),
+		TemplateId:  data.SbeTemplateId(),
+		SchemaId:    data.SbeSchemaId(),
+		Version:     data.SbeSchemaVersion(),
+	}
+	if !assert.NoError(t, header.Encode(m, buf)) {
+		return nil
+	}
+	if !assert.NoError(t, data.Encode(m, buf, false)) {
+		return nil
+	}
+	return atomic.MakeBuffer(buf.Bytes())
+}
+
+func newTestControl(t *testing.T) (*Control, *aeron.MockImage) {
+	image := aeron.NewMockImage(t)
+	c := &Control{
+		Subscription: newTestSub(image),
+	}
+	c.archive = &Archive{
+		Listeners: &ArchiveListeners{},
+		Options:   &Options{
+			Timeout: 100*time.Millisecond,
+			IdleStrategy: idlestrategy.Yielding{},
+		},
+	}
+	c.fragmentAssembler = aeron.NewControlledFragmentAssembler(
+		c.onFragment, aeron.DefaultFragmentAssemblyBufferLength,
+	)
+	return c, image
+}
+
+func newTestSub(image aeron.Image) *aeron.Subscription {
+	images := aeron.NewImageList()
+	images.Set([]aeron.Image{image})
+	sub := aeron.NewSubscription(nil, "", 1, 2, 3, nil, nil)
+	rsub := reflect.ValueOf(sub)
+	rfimages := rsub.Elem().FieldByName("images")
+	rfimages = reflect.NewAt(rfimages.Type(), unsafe.Pointer(rfimages.UnsafeAddr())).Elem()
+	rfimages.Set(reflect.ValueOf(images))
+	return sub
+}
+
+func newTestHeader() *logbuffer.Header {
+	buffer := atomic.MakeBuffer(make([]byte, logbuffer.DataFrameHeader.Length))
+	buffer.PutUInt8(logbuffer.DataFrameHeader.FlagsFieldOffset, 0xc0) // unfragmented
+	return new(logbuffer.Header).Wrap(buffer.Ptr(), buffer.Capacity())
+}


### PR DESCRIPTION
PollForResponse consumed responses after the response it was looking for in the incoming response stream, which specifically made it impossible to poll for replication initialization errors when setting up a replication, as they were consumed by the PollForResponse inside the Replicate operation.

This also updated PollForErrorResponse to reset the error between polls, or else it would just immediately return the previous error.

This also adds some tests for the two methods. The tests are nowhere near complete, but should give some coverage for the changes implemented here.
