### PR TITLE
Fix issue19: clustered_service_agent.onServiceAction does not send ack in case of an error.

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -308,8 +308,9 @@ func (cc *ClientConductor) run(idleStrategy idlestrategy.Idler) {
 			errStr := fmt.Sprintf("Panic: %v", err)
 			logger.Error(errStr)
 			cc.onError(errors.New(errStr))
-			cc.running.Set(false)
 		}
+
+		cc.running.Set(false)
 		cc.forceCloseResources()
 		cc.conductorRunning.Set(false)
 

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -603,13 +603,13 @@ func (archive *Archive) StopRecordingByPublication(publication aeron.Publication
 func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*aeron.Publication, error) {
 
 	// This can fail in aeron via log.Fatalf(), not much we can do
-	publication, err := archive.AddPublication(channel, stream)
+	publication, err := archive.AddExclusivePublication(channel, stream)
 	if err != nil {
 		return nil, err
 	}
-	if !publication.IsOriginal() {
-		return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
-	}
+	// if !publication.IsOriginal() {
+	// 	return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
+	// }
 
 	correlationID := nextCorrelationID()
 	logger.Debugf("AddRecordedPublication(), correlationID:%d", correlationID)
@@ -625,7 +625,7 @@ func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*a
 
 	archive.mtx.Lock()
 	defer archive.mtx.Unlock()
-	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, false, sessionChannel); err != nil {
+	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, true, sessionChannel); err != nil {
 		publication.Close()
 		return nil, err
 	}

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -744,12 +744,8 @@ func (agent *ClusteredServiceAgent) CancelTimer(correlationId int64) bool {
 }
 
 func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length int32) int64 {
-	if agent.role != Leader {
-		return ClientSessionMockedOffer
-	}
-
 	hdrBuf := agent.sessionMsgHdrBuffer
-	hdrBuf.PutInt64(SBEHeaderLength+8, -int64(agent.opts.ServiceId))
+	hdrBuf.PutInt64(SBEHeaderLength+8, int64(agent.opts.ServiceId))
 	hdrBuf.PutInt64(SBEHeaderLength+16, agent.clusterTime)
 	return agent.proxy.Offer2(hdrBuf, 0, hdrBuf.Capacity(), buffer, offset, length)
 }

--- a/cluster/consensus_module_proxy.go
+++ b/cluster/consensus_module_proxy.go
@@ -39,7 +39,7 @@ func newConsensusModuleProxy(
 // publication. Responses will be processed on the control
 
 // ConnectRequest packet and send
-func (proxy *consensusModuleProxy) serviceAckRequest(
+func (proxy *consensusModuleProxy) ack(
 	logPosition int64,
 	timestamp int64,
 	ackID int64,
@@ -108,16 +108,15 @@ func (proxy *consensusModuleProxy) send(payload []byte) {
 }
 
 func (proxy *consensusModuleProxy) offer(buffer *atomic.Buffer, offset, length int32) int64 {
-	var result int64
-	for i := 0; i < 3; i++ {
-		result = proxy.publication.Offer(buffer, offset, length, nil)
-		if result >= 0 {
-			break
-		} else if result == aeron.NotConnected || result == aeron.PublicationClosed || result == aeron.MaxPositionExceeded {
-			panic(fmt.Sprintf("offer failed, result=%d", result))
-		}
-	}
+	result := proxy.publication.Offer(buffer, offset, length, nil)
+	checkResult(result)
 	return result
+}
+
+func checkResult(result int64) {
+	if result == aeron.NotConnected || result == aeron.PublicationClosed || result == aeron.MaxPositionExceeded {
+		panic(fmt.Sprintf("unexpected publication state, result=%d", result))
+	}
 }
 
 func (proxy *consensusModuleProxy) Offer2(


### PR DESCRIPTION
Fix issue 19 of Aeron-Go audit by adaptive

			
## Description
clustered_service_agent.onServiceAction does not send ack in case of an error.
## Severity
Critical
## Implications 
An ack for a service action must be reliably sent (retried indefinitely) to the ConsensusModule always otherwise it will block forever waiting for it. In case of an error a NullValue should be sent instead of a recordingId.
## Code
- Go https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L545-L561
- Java https://github.com/real-logic/aeron/blob/154532e71d57fb90b51111c3caae02da4d10f47e/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L1006-L1036