### PR TITLE
Fire an error in archive client when the archive disconnects

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -225,6 +225,7 @@ func NewArchive(options *Options, context *aeron.Context) (*Archive, error) {
 	archive.Control.archive = archive
 	archive.Control.fragmentAssembler = aeron.NewControlledFragmentAssembler(
 		archive.Control.onFragment, aeron.DefaultFragmentAssemblyBufferLength)
+	archive.Control.errorFragmentHandler = archive.Control.errorResponseFragmentHandler
 
 	// Setup the Proxy (publisher/request)
 	archive.Proxy = new(Proxy)

--- a/archive/control.go
+++ b/archive/control.go
@@ -72,6 +72,8 @@ const (
 	ControlStateTimedOut           = iota
 )
 
+var ErrNotConnected = fmt.Errorf("not connected")
+
 // Used internally to handle connection state
 type controlState struct {
 	state int
@@ -360,7 +362,7 @@ func (control *Control) PollForErrorResponse() (int, error) {
 
 	control.Results.ErrorResponse = nil
 	if !control.Subscription.IsConnected() {
-		return received, fmt.Errorf("not connected")
+		return received, ErrNotConnected
 	}
 
 	// Poll for async events, errors etc until the queue is drained

--- a/archive/control.go
+++ b/archive/control.go
@@ -359,6 +359,9 @@ func (control *Control) PollForErrorResponse() (int, error) {
 	received := 0
 
 	control.Results.ErrorResponse = nil
+	if !control.Subscription.IsConnected() {
+		return received, fmt.Errorf("not connected")
+	}
 
 	// Poll for async events, errors etc until the queue is drained
 	for {


### PR DESCRIPTION
Check if control response connection is alive when polling for error from archive.

Changing the aeron-go `PollForErrorResponse` to check if the Control Subscription is connected to match the [C++](https://github.com/real-logic/aeron/blob/4cb1c900baaa6078b12ada7fec312ab51a49770d/aeron-archive/src/main/cpp/client/AeronArchive.h#L275-L278)/[Java](https://github.com/real-logic/aeron/blob/4cb1c900baaa6078b12ada7fec312ab51a49770d/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java#L435-L438) versions.

Fragment handler in PollForErrorResponse was escaping to heap due to poll argument being an interface, worked around this by making the error handler member variable casted to ControlledFragmentHandler during Archive initialization.