### PR TITLE
Ignore unknown messages from archive

### DIFF
--- a/aeron/driver/listeneradapter.go
+++ b/aeron/driver/listeneradapter.go
@@ -225,7 +225,6 @@ func (adapter *ListenerAdapter) ReceiveMessages() int {
 			adapter.listener.OnClientTimeout(msg.clientID.Get())
 		default:
 			// Note: Java silently ignores unhandled events
-			logger.Fatalf("received unhandled %d", msgTypeID)
 		}
 	}
 

--- a/archive/control.go
+++ b/archive/control.go
@@ -513,7 +513,7 @@ func (control *Control) errorResponseFragmentHandler(buffer *atomic.Buffer, offs
 		}
 
 	default:
-		fmt.Printf("errorResponseFragmentHandler: Insert decoder for type: %d", hdr.TemplateId)
+		// ignore any unknown messages to match other clients
 	}
 
 	return


### PR DESCRIPTION
Ignore any unknown codecs from archive (matches implementation of other clients)