### PR TITLE
Close image after unavailable

### DIFF
--- a/aeron/clientconductor_test.go
+++ b/aeron/clientconductor_test.go
@@ -16,13 +16,14 @@ package aeron
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/lirm/aeron-go/aeron/atomic"
 	"github.com/lirm/aeron-go/aeron/counters"
 	"github.com/lirm/aeron-go/aeron/testdata"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 const (
@@ -168,6 +169,7 @@ func (c *ClientConductorTestSuite) TestClientNotifiedOfNewAndInactiveImagesWithD
 	c.Require().Nil(unavailableHandler.GetHandledImage())
 
 	image.On("CorrelationID").Return(CorrelationId1)
+	image.On("Close").Return(nil)
 	c.cc.OnUnavailableImage(CorrelationId1, sub.RegistrationID())
 	c.Require().Equal(sub.ImageCount(), 0)
 	c.Require().Equal(unavailableHandler.GetHandledImage(), &image)
@@ -210,6 +212,7 @@ func (c *ClientConductorTestSuite) TestClientNotifiedOfNewAndInactiveImagesWithS
 	c.Require().Nil(unavailableHandler.GetHandledImage())
 
 	image.On("CorrelationID").Return(CorrelationId1)
+	image.On("Close").Return(nil)
 	c.cc.OnUnavailableImage(CorrelationId1, sub.RegistrationID())
 	c.Require().Equal(sub.ImageCount(), 0)
 	c.Require().Equal(unavailableHandler.GetHandledImage(), &image)

--- a/aeron/subscription.go
+++ b/aeron/subscription.go
@@ -260,6 +260,10 @@ func (sub *Subscription) removeImage(correlationID int64) Image {
 
 			sub.images.Set(img)
 
+			if err := image.Close(); err != nil {
+				logger.Infof("Error closing image %v for subscription %d: %v", image, sub.registrationID, err)
+			}
+
 			return image
 		}
 	}

--- a/aeron/subscription_test.go
+++ b/aeron/subscription_test.go
@@ -105,6 +105,17 @@ func (s *SubscriptionTestSuite) TestShouldReadDataFromMultipleSources() {
 	s.Assert().Equal(2, fragments)
 }
 
+func (s *SubscriptionTestSuite) TestShouldCloseImageOnRemoveImage() {
+	s.sub.addImage(s.imageOne)
+
+	s.imageOne.On("CorrelationID").Return(int64(1))
+	s.imageOne.On("Close").Return(nil)
+
+	s.sub.removeImage(1)
+
+	s.imageOne.AssertExpectations(s.T())
+}
+
 // TODO: Implement resolveChannel set of tests.
 
 func TestSubscription(t *testing.T) {


### PR DESCRIPTION
To match other clients, image should close (and release its counter) after it becomes unavailable.

Reference to Java implementation:
https://github.com/aeron-io/aeron/blob/master/aeron-client/src/main/java/io/aeron/Subscription.java#L615