### PR TITLE
Update PollForDescriptors to match C++/Java.

### DIFF
--- a/archive/control.go
+++ b/archive/control.go
@@ -828,7 +828,7 @@ func (control *Control) PollForDescriptors(correlationID int64, sessionID int64,
 			return nil
 		}
 
-		// Check wer're live
+		// Check we're live
 		if control.Subscription.IsClosed() {
 			return fmt.Errorf("response channel from archive is not connected")
 		}
@@ -847,9 +847,8 @@ func (control *Control) PollForDescriptors(correlationID int64, sessionID int64,
 		// If we are yet to receive anything then idle
 		if descriptorCount == 0 {
 			logger.Debugf("PollForDescriptors(%d:%d) idling with %d of %d", correlationID, sessionID, control.Results.FragmentsReceived, fragmentsWanted)
-			control.archive.Options.IdleStrategy.Idle(0)
 		}
-
+		control.archive.Options.IdleStrategy.Idle(0)
 	}
 	return nil
 }


### PR DESCRIPTION
I don't think this change actually has an impact since if fragments > 0 above, we continue immediately, but better safe than sorry.

See [C++](https://github.com/real-logic/aeron/blob/95540abb59ae699db72a9946d31f9974b0f40cf3/aeron-archive/src/main/cpp/client/AeronArchive.h#L2144) and [Java](https://github.com/real-logic/aeron/blob/95540abb59ae699db72a9946d31f9974b0f40cf3/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java#L2413) implementations.