### PR TITLE
Ignore unknown driver events instead of exiting

### DIFF
--- a/aeron/driver/listeneradapter.go
+++ b/aeron/driver/listeneradapter.go
@@ -224,8 +224,11 @@ func (adapter *ListenerAdapter) ReceiveMessages() int {
 
 			adapter.listener.OnClientTimeout(msg.clientID.Get())
 		default:
-			// Note: Java silently ignores unhandled events
-			logger.Fatalf("received unhandled %d", msgTypeID)
+			// Java silently ignores unhandled events. Newer drivers add event
+			// types (e.g. ON_NEXT_AVAILABLE_SESSION_ID), and responses meant
+			// for other clients arrive on the shared broadcast channel, so an
+			// unknown event must not be fatal.
+			logger.Debugf("ignoring unhandled driver event %d", msgTypeID)
 		}
 	}
 


### PR DESCRIPTION
## Problem

`ListenerAdapter.ReceiveMessages` calls `logger.Fatalf` when it receives a driver-to-client event it doesn't recognize, killing the process. Media drivers from Aeron 1.48+ broadcast new control response event types (e.g. `ON_NEXT_AVAILABLE_SESSION_ID`, `0x0F0D`), and since the broadcast channel is shared, responses intended for *other* clients on the same driver also arrive at every Go client.

In practice this means any Go client sharing a modern media driver with Java clients (an `ArchivingMediaDriver` or `ClusteredMediaDriver` being the common cases) dies within milliseconds of connecting:

```
fatal  driver  driver/listeneradapter.go:228  received unhandled 3853
```

## Fix

Log unknown events at debug level and continue, which is what the Java client does (the existing comment on this line already noted that: `// Note: Java silently ignores unhandled events`).

Found while running the Go cluster service container against a Java 1.52 `ClusteredMediaDriver`; with this fix the Go client works against current drivers.